### PR TITLE
Fix Twitter/X domain

### DIFF
--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -22,7 +22,7 @@ export class TwitterTimelineBehavior {
   static id = "Twitter"
 
   static isMatch() {
-    return !!window.location.href.match(/https:\/\/(www\.)?twitter\.com\//);
+    return !!window.location.href.match(/https:\/\/(www\.)?x\.com\//);
   }
 
   static init() {

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -22,7 +22,7 @@ export class TwitterTimelineBehavior {
   static id = "Twitter"
 
   static isMatch() {
-    return !!window.location.href.match(/https:\/\/(www\.)?x\.com\//);
+    return !!window.location.href.match(/https:\/\/(www\.)?(x|twitter)\.com\//);
   }
 
   static init() {


### PR DESCRIPTION
The Twitter behavior was still looking for the twitter.com domain, but this has changed to x.com, resulting in the Twitter behavior not starting on X. This PR should fix that.