### PR TITLE
improvements to autoscroll:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-behaviors",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "main": "index.js",
   "author": "Webrecorder Software",
   "license": "AGPL-3.0-or-later",

--- a/src/autoscroll.ts
+++ b/src/autoscroll.ts
@@ -58,13 +58,18 @@ export class AutoScroll extends Behavior {
       return false;
     }
 
+    // if page has iframes, do scroll
+    if (window.frames.length >= 2) {
+      return true;
+    }
+
     const lastScrollHeight = self.document.scrollingElement.scrollHeight;
     const numFetching = this.autoFetcher.numFetching;
 
     // scroll to almost end of page
     const scrollEnd = (document.scrollingElement.scrollHeight * 0.98) - self.innerHeight;
 
-    window.scrollTo({ top: scrollEnd, left: 0, behavior: "auto" });
+    window.scrollTo({ top: scrollEnd, left: 0, behavior: "smooth" });
 
     // wait for any updates
     await sleep(500);

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -31,7 +31,9 @@ export class FacebookTimelineBehavior {
   static id = "Facebook";
 
   static isMatch() {
-    return !!window.location.href.match(/https:\/\/(www\.)?facebook\.com\//);
+    // disable for now
+    return false;
+    //return !!window.location.href.match(/https:\/\/(www\.)?facebook\.com\//);
   }
 
   static init() {


### PR DESCRIPTION
- always autoscroll if at least 2 iframes
- use smooth scrolling during autoscroll check
- facebook: disable site-specific behavior until it is fixed, for now to just use autoscrol
- bump to 0.6.6