### PR TITLE
Log behavior name and siteSpecific: true for site-specific behaviors

### DIFF
--- a/.github/workflows/autoscroll.yaml
+++ b/.github/workflows/autoscroll.yaml
@@ -35,11 +35,11 @@ jobs:
       run:  docker pull $BROWSERTRIX_IMAGE
 
     - name: run crawl
-      run: docker run -v $PWD/dist/behaviors.js:/app/node_modules/browsertrix-behaviors/dist/behaviors.js $BROWSERTRIX_IMAGE crawl --url https://www.iana.org/numbers --limit 1 --logging behaviors --logLevel debug --behaviors autoscroll > ./log
+      run: docker run -v $PWD/dist/behaviors.js:/app/node_modules/browsertrix-behaviors/dist/behaviors.js $BROWSERTRIX_IMAGE crawl --url https://www.iana.org/numbers --limit 1 --logging debug --context behaviorScript --behaviors autoscroll > ./log
 
-    - name: cat log
-      run: cat ./log
+    - name: check for autoscroll debug log line
+      run: grep 'Skipping autoscroll, page seems to not be responsive to scrolling events' ./log
 
-    - name: compare crawl log to expected
-      run: cat ./log | jq -c 'select(.context == "behaviorScript") | .details' | diff - ./test/expected-autoscroll.log
+    - name: check that state is logged as well
+      run: grep '{"state":{"segments":1}' ./log
 

--- a/.github/workflows/autoscroll.yaml
+++ b/.github/workflows/autoscroll.yaml
@@ -35,7 +35,7 @@ jobs:
       run:  docker pull $BROWSERTRIX_IMAGE
 
     - name: run crawl
-      run: docker run -v $PWD/dist/behaviors.js:/app/node_modules/browsertrix-behaviors/dist/behaviors.js $BROWSERTRIX_IMAGE crawl --url https://www.iana.org/numbers --limit 1 --logging behaviors --behaviors autoplay,autofetch,autoscroll > ./log
+      run: docker run -v $PWD/dist/behaviors.js:/app/node_modules/browsertrix-behaviors/dist/behaviors.js $BROWSERTRIX_IMAGE crawl --url https://www.iana.org/numbers --limit 1 --logging behaviors --logLevel debug --behaviors autoscroll > ./log
 
     - name: cat log
       run: cat ./log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-behaviors",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "index.js",
   "author": "Webrecorder Software",
   "license": "AGPL-3.0-or-later",

--- a/src/autoclick.ts
+++ b/src/autoclick.ts
@@ -10,6 +10,8 @@ export class AutoClick extends BackgroundBehavior
   selector: string;
   seenElem = new WeakSet<HTMLElement>();
 
+  static id = "Autoclick";
+
   constructor(selector = "a") {
     super();
     this.selector = selector;

--- a/src/autofetcher.ts
+++ b/src/autofetcher.ts
@@ -37,7 +37,7 @@ export class AutoFetcher extends BackgroundBehavior {
   active: boolean;
   running = false;
 
-  static id = "AutoFetcher";
+  static id = "Autofetcher";
 
   constructor(active = false, headers = null, startEarly = false) {
     super();

--- a/src/lib/behavior.ts
+++ b/src/lib/behavior.ts
@@ -167,14 +167,20 @@ export class BehaviorRunner extends BackgroundBehavior {
   async run() {
     try {
       for await (const step of this.inst.run(this.ctx)) {
-        this.log({msg: step, behavior: this.behaviorProps.id, siteSpecific: true});
+        let logStep;
+        if (typeof step === "string" || step instanceof String) {
+          logStep = {msg: step}
+        } else {
+          logStep = step;
+        }
+        this.log({...logStep, behavior: this.behaviorProps.id, siteSpecific: true});
         if (this.paused) {
           await this.paused;
         }
       }
       this.log({msg: "done!", behavior: this.behaviorProps.id, siteSpecific: true});
     } catch (e) {
-      this.log({msg: e.toString(), behavior: this.behaviorProps.id, siteSpecific: true});
+      this.log({msg: "error", error: e.toString(), behavior: this.behaviorProps.id, siteSpecific: true});
     }
   }
 

--- a/src/lib/behavior.ts
+++ b/src/lib/behavior.ts
@@ -43,15 +43,14 @@ export class Behavior extends BackgroundBehavior {
   async run() {
     try {
       for await (const step of this) {
-        this.log({msg: step, behavior: this.id, customBehavior: false});
+        this.log(step);
         if (this.paused) {
           await this.paused;
         }
       }
-      this.log({msg: "done!", behavior: this.id, customBehavior: false});
+      this.log(this.getState("done!"));
     } catch (e) {
-      const state = this.getState(e.toString());
-      this.log({...state, behavior: this.id, customBehavior: false});
+      this.log(this.getState(e));
     }
   }
 

--- a/src/lib/behavior.ts
+++ b/src/lib/behavior.ts
@@ -54,7 +54,7 @@ export class Behavior extends BackgroundBehavior {
       }
       this.debug(this.getState("done!"));
     } catch (e) {
-      this.debug(this.getState(e));
+      this.error(e.toString());
     }
   }
 

--- a/src/lib/behavior.ts
+++ b/src/lib/behavior.ts
@@ -50,7 +50,7 @@ export class Behavior extends BackgroundBehavior {
       }
       this.log({msg: "done!", behavior: this.id, customBehavior: false});
     } catch (e) {
-      let state = this.getState(e.toString());
+      const state = this.getState(e.toString());
       this.log({...state, behavior: this.id, customBehavior: false});
     }
   }

--- a/src/lib/behavior.ts
+++ b/src/lib/behavior.ts
@@ -43,14 +43,15 @@ export class Behavior extends BackgroundBehavior {
   async run() {
     try {
       for await (const step of this) {
-        this.log(step);
+        this.log({msg: step, behavior: this.id, customBehavior: false});
         if (this.paused) {
           await this.paused;
         }
       }
-      this.log(this.getState("done!"));
+      this.log({msg: "done!", behavior: this.id, customBehavior: false});
     } catch (e) {
-      this.log(this.getState(e));
+      let state = this.getState(e.toString());
+      this.log({...state, behavior: this.id, customBehavior: false});
     }
   }
 
@@ -167,14 +168,14 @@ export class BehaviorRunner extends BackgroundBehavior {
   async run() {
     try {
       for await (const step of this.inst.run(this.ctx)) {
-        this.log({message: step, behavior: this.behaviorProps.id, customBehavior: true});
+        this.log({msg: step, behavior: this.behaviorProps.id, customBehavior: true});
         if (this.paused) {
           await this.paused;
         }
       }
-      this.log({message: "done!", behavior: this.behaviorProps.id, customBehavior: true});
+      this.log({msg: "done!", behavior: this.behaviorProps.id, customBehavior: true});
     } catch (e) {
-      this.log({error: e.toString(), behavior: this.behaviorProps.id, customBehavior: true});
+      this.log({msg: e.toString(), behavior: this.behaviorProps.id, customBehavior: true});
     }
   }
 

--- a/src/lib/behavior.ts
+++ b/src/lib/behavior.ts
@@ -7,6 +7,10 @@ export class BackgroundBehavior {
     behaviorLog(msg, "debug");
   }
 
+  error(msg) {
+    behaviorLog(msg, "error");
+  }
+
   log(msg) {
     behaviorLog(msg, "info");
   }
@@ -180,7 +184,7 @@ export class BehaviorRunner extends BackgroundBehavior {
       }
       this.log({msg: "done!", behavior: this.behaviorProps.id, siteSpecific: true});
     } catch (e) {
-      this.log({msg: "error", error: e.toString(), behavior: this.behaviorProps.id, siteSpecific: true});
+      this.error({msg: e.toString(), behavior: this.behaviorProps.id, siteSpecific: true});
     }
   }
 

--- a/src/lib/behavior.ts
+++ b/src/lib/behavior.ts
@@ -43,14 +43,14 @@ export class Behavior extends BackgroundBehavior {
   async run() {
     try {
       for await (const step of this) {
-        this.log(step);
+        this.debug(step);
         if (this.paused) {
           await this.paused;
         }
       }
-      this.log(this.getState("done!"));
+      this.debug(this.getState("done!"));
     } catch (e) {
-      this.log(this.getState(e));
+      this.debug(this.getState(e));
     }
   }
 

--- a/src/lib/behavior.ts
+++ b/src/lib/behavior.ts
@@ -167,14 +167,14 @@ export class BehaviorRunner extends BackgroundBehavior {
   async run() {
     try {
       for await (const step of this.inst.run(this.ctx)) {
-        this.log({msg: step, behavior: this.behaviorProps.id, customBehavior: true});
+        this.log({msg: step, behavior: this.behaviorProps.id, siteSpecific: true});
         if (this.paused) {
           await this.paused;
         }
       }
-      this.log({msg: "done!", behavior: this.behaviorProps.id, customBehavior: true});
+      this.log({msg: "done!", behavior: this.behaviorProps.id, siteSpecific: true});
     } catch (e) {
-      this.log({msg: e.toString(), behavior: this.behaviorProps.id, customBehavior: true});
+      this.log({msg: e.toString(), behavior: this.behaviorProps.id, siteSpecific: true});
     }
   }
 

--- a/src/lib/behavior.ts
+++ b/src/lib/behavior.ts
@@ -167,14 +167,14 @@ export class BehaviorRunner extends BackgroundBehavior {
   async run() {
     try {
       for await (const step of this.inst.run(this.ctx)) {
-        this.log(step);
+        this.log({message: step, behavior: this.behaviorProps.id, customBehavior: true});
         if (this.paused) {
           await this.paused;
         }
       }
-      this.log("done!");
+      this.log({message: "done!", behavior: this.behaviorProps.id, customBehavior: true});
     } catch (e) {
-      this.log(e.toString());
+      this.log({error: e.toString(), behavior: this.behaviorProps.id, customBehavior: true});
     }
   }
 

--- a/test/expected-autoscroll.log
+++ b/test/expected-autoscroll.log
@@ -1,2 +1,0 @@
-{"state":{"segments":1},"msg":"Skipping autoscroll, page seems to not be responsive to scrolling events","page":"https://www.iana.org/numbers","workerid":0}
-{"state":{"segments":1},"msg":"done!","page":"https://www.iana.org/numbers","workerid":0}


### PR DESCRIPTION
Fixes #91 

Additionally log built-in non-site specific behaviors to debug instead of info to reduce noise from autoscroll logs.

I tested running the built `dist/behaviors.js` file in the console on Twitter and this change did not seem to impact that logging.

It does however lead to crawl logs that have more information about the site-specific behaviors that are being run, which will be useful for users in Browsertrix and might enable us to filter on only site-specific behaviors or by behavior as well.

```jsonl
{"timestamp":"2025-04-02T15:54:37.165Z","logLevel":"info","context":"behaviorScript","message":"Behavior log","details":{"pages":0,"behavior":"Fulcrum","siteSpecific":true,"page":"https://www.fulcrum.org/epubs/j9602290q#/6/4[Copyright01]!/4/2[cip]/2/2/1:0","workerid":0}}
{"timestamp":"2025-04-02T15:54:42.172Z","logLevel":"info","context":"behaviorScript","message":"Behavior log","details":{"pages":1,"behavior":"Fulcrum","siteSpecific":true,"page":"https://www.fulcrum.org/epubs/j9602290q#/6/6[Contents]!/4/2/2[toc]/2/1:0","workerid":0}}
{"timestamp":"2025-04-02T15:54:47.176Z","logLevel":"info","context":"behaviorScript","message":"Behavior log","details":{"pages":2,"behavior":"Fulcrum","siteSpecific":true,"page":"https://www.fulcrum.org/epubs/j9602290q#/6/8[HalfTitle]!/4/2[bk]/2/2[p1]/1:0","workerid":0}}
{"timestamp":"2025-04-02T15:56:13.015Z","logLevel":"info","context":"behaviorScript","message":"Behavior log","details":{"state":{"comments":0},"msg":"TikTok Video Behavior Complete","behavior":"TikTokVideo","siteSpecific":true,"page":"https://www.tiktok.com/@montrealgems/video/7465099592636452101","workerid":0}}
{"timestamp":"2025-04-02T15:56:13.015Z","logLevel":"info","context":"behaviorScript","message":"Behavior log","details":{"msg":"done!","behavior":"TikTokVideo","siteSpecific":true,"page":"https://www.tiktok.com/@montrealgems/video/7465099592636452101","workerid":0}}
```