### PR TITLE
Add logged in content check for siteSpecific behaviors!

### DIFF
--- a/src/autoscroll.ts
+++ b/src/autoscroll.ts
@@ -40,7 +40,7 @@ export class AutoScroll extends Behavior {
   hasScrollEL(obj) {
     try {
       return !!self["getEventListeners"](obj).scroll;
-    } catch (e) {
+    } catch (_) {
       // unknown, assume has listeners
       this.debug("getEventListeners() not available");
       return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ import { Autoplay } from "./autoplay";
 import { AutoScroll } from "./autoscroll";
 import { AutoClick } from "./autoclick";
 import { awaitLoad, sleep, behaviorLog, _setLogFunc, _setBehaviorManager, installBehaviors, addLink, checkToJsonOverride } from "./lib/utils";
-import { Behavior, BehaviorRunner } from "./lib/behavior";
+import { type Behavior, BehaviorRunner } from "./lib/behavior";
+import * as Lib from "./lib/utils";
+
 
 import siteBehaviors from "./site";
 
@@ -208,10 +210,13 @@ export class BehaviorManager {
   }
 
   async awaitPageLoad() {
+    behaviorLog("Test");
     this.selectMainBehavior();
     if (this.mainBehavior?.awaitPageLoad) {
       behaviorLog("Waiting for custom page load via behavior");
-      await this.mainBehavior.awaitPageLoad();
+      await this.mainBehavior.awaitPageLoad({Lib});
+    } else {
+      behaviorLog("No custom wait behavior");
     }
   }
 

--- a/src/lib/behavior.ts
+++ b/src/lib/behavior.ts
@@ -91,7 +91,7 @@ export class Behavior extends BackgroundBehavior {
 
   }
 
-  async awaitPageLoad() {
+  async awaitPageLoad(_: any) {
     // wait for initial page load here
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -155,6 +155,16 @@ export async function nextFlowStep(id: number) : Promise<any> {
   return {done: true, msg: ""};
 }
 
+export function assertContentValid(assertFunc: () => boolean, reason = "invalid") {
+  if (typeof(self["__bx_contentCheckFailed"]) === "function") {
+    if (!assertFunc()) {
+      behaviorLog("Behavior content check failed: " + reason, "error");
+      callBinding(self["__bx_contentCheckFailed"], reason);
+    }
+  }
+}
+
+
 export async function openWindow(url) {
   if (self["__bx_open"]) {
     const p = new Promise((resolve) => self["__bx_openResolve"] = resolve);

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -22,6 +22,8 @@ const Q = {
   isPhotoVideoPage: /^.*facebook\.com\/[^/]+\/(photos|videos)\/.+/,
   isPhotosPage: /^.*facebook\.com\/[^/]+\/photos\/?($|\?)/,
   isVideosPage: /^.*facebook\.com\/[^/]+\/videos\/?($|\?)/,
+
+  pageLoadWaitUntil: "//div[@role='main']"
 };
 
 export class FacebookTimelineBehavior {
@@ -31,9 +33,8 @@ export class FacebookTimelineBehavior {
   static id = "Facebook";
 
   static isMatch() {
-    // disable for now
-    return false;
-    //return !!window.location.href.match(/https:\/\/(www\.)?facebook\.com\//);
+    // match just for posts for now
+    return !!window.location.href.match(/https:\/\/(www\.)?facebook\.com\/.*\/posts\//);
   }
 
   static init() {
@@ -385,5 +386,16 @@ export class FacebookTimelineBehavior {
 
     ctx.state = { "posts": 0, "comments": 0, "videos": 0 };
     yield* this.iterPostFeeds(ctx);
+  }
+
+  async awaitPageLoad(ctx: any) {
+    const { Lib, log } = ctx;
+    const { assertContentValid, waitUntilNode } = Lib;
+
+    log("Waiting for Facebook to fully load", "info");
+
+    await waitUntilNode(Q.pageLoadWaitUntil, document, null, 10000);
+
+    assertContentValid(() => !!document.querySelector("div[aria-label*='Account Controls' i]"), "not_logged_in");
   }
 }

--- a/src/site/instagram.ts
+++ b/src/site/instagram.ts
@@ -251,10 +251,12 @@ export class InstagramPostsBehavior {
 
   async awaitPageLoad(ctx: any) {
     const { Lib, log } = ctx;
-    const { waitUntilNode } = Lib;
+    const { assertContentValid, waitUntilNode } = Lib;
 
-    log("Waiting for Instagram to fully load", "info");
+    log("Waiting for Instagram to fully load");
 
-    await waitUntilNode(Q.pageLoadWaitUntil, document, null, 30000);
+    await waitUntilNode(Q.pageLoadWaitUntil, document, null, 10000);
+
+    assertContentValid(() => !!document.querySelector("*[aria-label='New post']"), "not_logged_in");
   }
 }

--- a/src/site/tiktok.ts
+++ b/src/site/tiktok.ts
@@ -5,7 +5,9 @@ const Q = {
   viewMoreThread: ".//p[starts-with(@data-e2e, 'view-more') and string-length(text()) > 0]",
   profileVideoList: "//div[starts-with(@data-e2e, 'user-post-item-list')]",
   profileVideoItem: "div[contains(@class, 'DivItemContainerV2')]",
-  backButton: "button[contains(@class, 'StyledCloseIconContainer')]"
+  backButton: "button[contains(@class, 'StyledCloseIconContainer')]",
+
+  pageLoadWaitUntil: "//*[@role='dialog']"
 };
 
 export const BREADTH_ALL = Symbol("BREADTH_ALL");
@@ -101,5 +103,12 @@ export class TikTokProfileBehavior {
       await sleep(500);
     }
     yield getState(ctx, "TikTok Profile Behavior Complete");
+  }
+
+  async awaitPageLoad(ctx: any) {
+    const { assertContentValid, waitUntilNode } = ctx.Lib;
+    await waitUntilNode(Q.pageLoadWaitUntil, document, null, 10000);
+
+    assertContentValid(() => !!document.querySelector("*[aria-label='Messages']"), "not_logged_in");
   }
 }

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -282,4 +282,10 @@ export class TwitterTimelineBehavior {
   async* run(ctx) {
     yield* this.iterTimeline(ctx, 0);
   }
+
+  async awaitPageLoad(ctx: any) {
+    const { sleep, assertContentValid } = ctx.Lib;
+    await sleep(5);
+    assertContentValid(() => !document.documentElement.outerHTML.match(/Log In/i), "not_logged_in");
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ const tsConfig = (_env, argv) => {
     mode: argv.mode,
     plugins: [
       new webpack.BannerPlugin(`behaviors.js is part of Webrecorder project. Copyright (C) 2021-${new Date().getFullYear()}, Webrecorder Software. Licensed under the Affero General Public License v3.`),
-      new webpack.ProgressPlugin()
+      new webpack.ProgressPlugin(),
+      new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1})
     ],
     entry: "./index.ts",
     module: {


### PR DESCRIPTION
- Add logged in validation to site-specific behaviors in awaitPageLoad()
- use new exposed function, `__bx_contentCheckFailed `, if it exists, otherwise do nothing.
- fixes #99 