### PR TITLE
docs: expand social media behaviour docs, update tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,26 @@ Alternatively, calling `await __bx_behaviors.run(opts)` will also call `init(opt
 
 The promised returned by run will wait for the active behavior to finish, for the `timeout` time to be reached. It will also ensure any pending autoplay requests are started for the `autoplay` behavior.
 
+#### Supported features
+
+The following features are expected to work for each of these site-specific behaviors:
+
+##### Facebook
+
+- Capturing a home timeline
+- Capturing single posts
+- Capturing business/organization pages, including posts within those pages
+- Capturing photos and videos
+
+##### Instagram
+
+- Capturing all subposts within every post
+- Expanding comment threads and capturing all comments
+- Capturing a single post
+- Capturing a profile, including the full content of every post on that profile
+- Capturing photos and videos
+- Extra media in "+N" click-through carousels
+
 ## Logging
 
 By default, behaviors will log debug messages to `console.log`. To disable this logging, set `log: false` in the init options.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The following features are expected to work for each of these site-specific beha
 - Capturing a single post
 - Capturing a profile, including the full content of every post on that profile
 - Capturing photos and videos
+- Capturing ephemeral stories from the story carousel
 - Capturing stories with each story loaded via it's unique URL.
 - Extra media in "+N" click-through carousels
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The following features are expected to work for each of these site-specific beha
 - Capturing a single post
 - Capturing a profile, including the full content of every post on that profile
 - Capturing photos and videos
+- Capturing stories with each story loaded via it's unique URL.
 - Extra media in "+N" click-through carousels
 
 ## Logging

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -314,7 +314,7 @@ for await (const item of commentItems) {
 ```
 
 Our behavior now yields a result each time we scroll to a comment, and the
-extension can now pause and resume the scrolling behavior.
+extension can now pause and resume the scrolling behavior. The last argument is a counter that's incremented by 1 every time `getState` is called with it; this is included in logs, so it can be helpful to identify how many times we've called `getState` in a particular place. The example above, for instance, will give us a count of all times we called `getState` with `"threads"`.
 
 ## 📖 Expanding comment threads
 


### PR DESCRIPTION
This contains a couple of changes:

* Adds a section to the README identifying what features we expect to work on the social media sites we have builtin behaviours for. Right now it covers Facebook and Instagram; I'll expand the other sites when we look at them next. Does it look like I missed anything?
* Adds a section to the tutorial explaning what the "accumulating totals" are for the `getState` function.