### PR TITLE
facebook: update photo page query

### DIFF
--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -16,11 +16,12 @@ const Q = {
   nextSlide:
     "//div[@aria-hidden='false']//div[@role='button' and not(@aria-hidden) and @aria-label]",
   commentList: ".//ul[(../h3) or (../h4)]",
-  commentMoreReplies: "./div[2]/div[1]/div[2]/div[@role='button']",
+  commentMoreReplies:
+    ".//span[contains(text(), 'View all')]/parent::span/parent::div[@role='button']",
   commentMoreComments:
-    "./following-sibling::div/div/div[2][@role='button'][./span/span]",
+    ".//span[text() = 'View more comments']/parent::span/parent::div[@role='button']",
   viewComments: ".//h4/..//div[@role='button']",
-  photoCommentList: "//ul[../h2]",
+  photoCommentList: "//h2[contains(text(), 'Comments')]/parent::div",
   commentFilterDropdown:
     "//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
   commentFilterAllComments:
@@ -263,11 +264,11 @@ export class FacebookTimelineBehavior
 
   async *iterComments(
     ctx: Context<FacebookState>,
-    commentRootUL: HTMLUListElement | null,
+    commentRoot: HTMLElement | null,
     maxExpands = 2,
   ) {
     const { getState, scrollIntoView, sleep, waitUnit, xpathNode } = ctx.Lib;
-    if (!commentRootUL) {
+    if (!commentRoot) {
       await sleep(waitUnit * 5);
       return;
     }
@@ -289,7 +290,10 @@ export class FacebookTimelineBehavior
       }
     }
 
-    let commentBlock = commentRootUL.firstElementChild;
+    let commentBlock = xpathNode(
+      "div[2]/div[1]",
+      commentRoot,
+    ) as HTMLElement | null;
     let lastBlock: Element | null = null;
 
     let count = 0;
@@ -300,17 +304,26 @@ export class FacebookTimelineBehavior
         scrollIntoView(commentBlock);
         await sleep(waitUnit * 2);
 
-        const moreReplies = xpathNode(
+        let moreReplies = xpathNode(
           Q.commentMoreReplies,
           commentBlock,
         ) as HTMLElement | null;
-        if (moreReplies) {
+        while (moreReplies) {
+          scrollIntoView(moreReplies);
+          // TODO: apply maxExpands per-comment or per-click?
           moreReplies.click();
           await sleep(waitUnit * 5);
+          // There can be additional "more replies" buttons
+          // within nested comment chains, so keep searching
+          // for them until we've fully exhausted them.
+          moreReplies = xpathNode(
+            Q.commentMoreReplies,
+            commentBlock,
+          ) as HTMLElement | null;
         }
 
         lastBlock = commentBlock;
-        commentBlock = lastBlock.nextElementSibling;
+        commentBlock = lastBlock.nextElementSibling as HTMLElement | null;
         count++;
       }
 
@@ -320,14 +333,14 @@ export class FacebookTimelineBehavior
 
       const moreButton = xpathNode(
         Q.commentMoreComments,
-        commentRootUL,
+        commentRoot,
       ) as HTMLElement | null;
       if (moreButton) {
         scrollIntoView(moreButton);
         moreButton.click();
         await sleep(waitUnit * 5);
         if (lastBlock) {
-          commentBlock = lastBlock.nextElementSibling;
+          commentBlock = lastBlock.nextElementSibling as HTMLElement | null;
           await sleep(waitUnit * 5);
         }
       }
@@ -375,7 +388,7 @@ export class FacebookTimelineBehavior
 
       yield getState(ctx, `Viewing photo ${window.location.href}`, "photos");
 
-      const root = xpathNode(Q.photoCommentList) as HTMLUListElement | null;
+      const root = xpathNode(Q.photoCommentList) as HTMLElement | null;
       yield* this.iterComments(ctx, root, 2);
 
       await sleep(waitUnit * 5);

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -22,7 +22,7 @@ const Q = {
   viewComments: ".//h4/..//div[@role='button']",
   photoCommentList: "//ul[../h2]",
   firstPhotoThumbnail:
-    "//div[@role='main']//div[3]//div[contains(@style, 'border-radius')]//div[contains(@style, 'max-width') and contains(@style, 'min-width')]//a[@role='link']",
+    "//div[@role='main']//div[@data-pagelet='ProfileAppSection_0']//div[3]/div[1]/div[1]//a[@role='link']",
   firstVideoThumbnail:
     "//div[@role='main']//div[contains(@style, 'z-index')]/following-sibling::div/div/div/div[last()]//a[contains(@href, '/videos/') and @aria-hidden!='true']",
   firstVideoSimple:

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -139,11 +139,8 @@ export class FacebookTimelineBehavior
 
     //yield* this.viewPhotosOrVideos(ctx, post);
 
-    let commentRootUL = xpathNode(
-      Q.commentList,
-      post,
-    ) as HTMLUListElement | null;
-    if (!commentRootUL) {
+    let commentRoot = xpathNode(Q.commentList, post) as HTMLElement | null;
+    if (!commentRoot) {
       const viewCommentsButton = xpathNode(
         Q.viewComments,
         post,
@@ -152,9 +149,9 @@ export class FacebookTimelineBehavior
         viewCommentsButton.click();
         await sleep(waitUnit * 2);
       }
-      commentRootUL = xpathNode(Q.commentList, post) as HTMLUListElement | null;
+      commentRoot = xpathNode(Q.commentList, post) as HTMLElement | null;
     }
-    yield* this.iterComments(ctx, commentRootUL, maxExpands);
+    yield* this.iterComments(ctx, commentRoot, maxExpands);
 
     await sleep(waitUnit * 5);
   }
@@ -480,7 +477,7 @@ export class FacebookTimelineBehavior
 
     if (Q.isPhotoVideoPage.exec(window.location.href)) {
       ctx.state = { comments: 0 };
-      const root = xpathNode(Q.photoCommentList) as HTMLUListElement | null;
+      const root = xpathNode(Q.photoCommentList) as HTMLElement | null;
       yield* this.iterComments(ctx, root, 1000);
       return;
     }

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -21,6 +21,10 @@ const Q = {
     "./following-sibling::div/div/div[2][@role='button'][./span/span]",
   viewComments: ".//h4/..//div[@role='button']",
   photoCommentList: "//ul[../h2]",
+  commentFilterDropdown:
+    "//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
+  commentFilterAllComments:
+    "//div[@role='menuitem']//span[contains(text(), 'All comments')]",
   firstPhotoThumbnail:
     "//div[@role='main']//div[@data-pagelet='ProfileAppSection_0']//div[3]/div[1]/div[1]//a[@role='link']",
   firstVideoThumbnail:
@@ -267,6 +271,24 @@ export class FacebookTimelineBehavior
       await sleep(waitUnit * 5);
       return;
     }
+
+    // If there's a comment filter, try to set it to "All Comments"
+    const filterDropdown = xpathNode(
+      Q.commentFilterDropdown,
+    ) as HTMLElement | null;
+    if (filterDropdown) {
+      filterDropdown.click();
+      const allComments = xpathNode(
+        Q.commentFilterAllComments,
+        filterDropdown,
+      ) as HTMLElement | null;
+      // Clicking this will automatically close the dropdown so we don't
+      // have to worry about manually closing it
+      if (allComments) {
+        allComments.click();
+      }
+    }
+
     let commentBlock = commentRootUL.firstElementChild;
     let lastBlock: Element | null = null;
 

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -58,10 +58,7 @@ export class FacebookTimelineBehavior
   static id = "Facebook" as const;
 
   static isMatch() {
-    // match just for posts for now
-    return !!window.location.href.match(
-      /https:\/\/(www\.)?facebook\.com\/.*\/posts\//,
-    );
+    return !!window.location.href.match(/https:\/\/(www\.)?facebook\.com\//);
   }
 
   static init() {


### PR DESCRIPTION
I've been auditing the current Facebook queries. These have drifted from the current version of the site, but also the PRs from a bit back. I tested this on a few live photo pages, and confirmed that this makes it possible to click into a photo, and the "iterate slides" feature still works to navigate from one page to the next. I'm midway through updating comment support, which will require further changes.