### PR TITLE
facebook: add reels support

### DIFF
--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -62,10 +62,7 @@ export class FacebookTimelineBehavior
   static id = "Facebook" as const;
 
   static isMatch() {
-    // match just for posts for now
-    return !!window.location.href.match(
-      /https:\/\/(www\.)?facebook\.com\/.*\/posts\//,
-    );
+    return !!window.location.href.match(/https:\/\/(www\.)?facebook\.com\//);
   }
 
   static init() {
@@ -460,7 +457,8 @@ export class FacebookTimelineBehavior
 
     await sleep(waitUnit * 10);
 
-    let nextButton = xpathNode(Q.nextReelCard) as HTMLElement | null;
+    let nextButton = (xpathNode(Q.nextReelCard) ||
+      xpathNode(Q.nextReelCardAlt)) as HTMLElement | null;
 
     while (nextButton) {
       yield getState(ctx, "Viewing reel: " + window.location.href, "reels");
@@ -481,7 +479,8 @@ export class FacebookTimelineBehavior
 
       await sleep(waitUnit * 10);
 
-      nextButton = xpathNode(Q.nextReelCard) as HTMLElement | null;
+      nextButton = (xpathNode(Q.nextReelCard) ||
+        xpathNode(Q.nextReelCardAlt)) as HTMLElement | null;
 
       if (nextButton) {
         nextButton.click();

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -27,6 +27,13 @@ const Q = {
     "//div[@role='main']//div[contains(@style, 'z-index')]/following-sibling::div/div/div/div[last()]//a[contains(@href, '/videos/') and @aria-hidden!='true']",
   firstVideoSimple:
     "//div[@role='main']//a[contains(@href, '/videos/') and @aria-hidden!='true']",
+  firstReelThumbnail:
+    "//div[@role='main']//div[contains(@style, 'z-index')]/following-sibling::div/div/div/div[last()]//a[contains(@href, '/reel/')]",
+  firstReelSimple: "//div[@role='main']//a[contains(@href, '/reel/')]",
+  // Horizontal layout
+  nextReelCard: "//div[@role='main']/div[2]/div[2]/div[@role='button']",
+  // Vertical layout
+  nextReelCardAlt: "//div[@role='main']/div/div/div/div[3][@role='button']",
   mainVideo:
     "//div[@data-pagelet='root']//div[@role='dialog']//div[@role='main']//video",
   nextVideo:
@@ -34,11 +41,13 @@ const Q = {
   isPhotoVideoPage: /^.*facebook\.com\/[^/]+\/(photos|videos)\/.+/,
   isPhotosPage: /^.*facebook\.com\/[^/]+\/photos\/?($|\?)/,
   isVideosPage: /^.*facebook\.com\/[^/]+\/videos\/?($|\?)/,
+  isReelsPage: /^.*facebook\.com\/[^/]+\/reels\/?($|\?)/,
   pageLoadWaitUntil: "//div[@role='main']",
 };
 
 type FacebookState = Partial<{
   photos: number;
+  reels: number;
   videos: number;
   comments: number;
   posts: number;
@@ -425,6 +434,63 @@ export class FacebookTimelineBehavior
     }
   }
 
+  async *iterAllReels(ctx: Context<FacebookState>) {
+    const {
+      getState,
+      scrollIntoView,
+      sleep,
+      waitUnit,
+      waitUntil,
+      xpathNode,
+      xpathNodes,
+    } = ctx.Lib;
+
+    const videoLink = (xpathNode(Q.firstReelThumbnail) ||
+      xpathNode(Q.firstReelSimple)) as HTMLElement | null;
+
+    if (!videoLink) {
+      return;
+    }
+
+    scrollIntoView(videoLink);
+
+    let lastHref = window.location.href;
+    videoLink.click();
+    await waitUntil(() => window.location.href !== lastHref, waitUnit * 2);
+
+    await sleep(waitUnit * 10);
+
+    let nextButton = xpathNode(Q.nextReelCard) as HTMLElement | null;
+
+    while (nextButton) {
+      yield getState(ctx, "Viewing reel: " + window.location.href, "reels");
+      // wait for video to play, or 20s
+      await Promise.race([
+        waitUntil(() => {
+          for (const video of xpathNodes(
+            "//video",
+          ) as Generator<HTMLVideoElement>) {
+            if (video.readyState >= 3) {
+              return true;
+            }
+          }
+          return false;
+        }, waitUnit * 2),
+        sleep(20000),
+      ]);
+
+      await sleep(waitUnit * 10);
+
+      nextButton = xpathNode(Q.nextReelCard) as HTMLElement | null;
+
+      if (nextButton) {
+        nextButton.click();
+        lastHref = window.location.href;
+        await waitUntil(() => window.location.href !== lastHref, waitUnit * 2);
+      }
+    }
+  }
+
   async *run(ctx: Context<FacebookState>) {
     const { getState, sleep, xpathNode } = ctx.Lib;
     yield getState(ctx, "Starting...");
@@ -440,6 +506,12 @@ export class FacebookTimelineBehavior
     if (Q.isVideosPage.exec(window.location.href)) {
       ctx.state = { videos: 0, comments: 0 };
       yield* this.iterAllVideos(ctx);
+      return;
+    }
+
+    if (Q.isReelsPage.exec(window.location.href)) {
+      ctx.state = { reels: 0, comments: 0 };
+      yield* this.iterAllReels(ctx);
       return;
     }
 


### PR DESCRIPTION
This adds support for visiting reels pages. Similar to photos, it starts from the `/page/reels/` URL, clicks the first thumbnail, and then iterates through reels by clicking the next button. Currently, I haven't set a limit on how many videos it should try to visit; it will just keep going until it hits the configured timeout.

There are two different reels layouts that can be seen on desktop - a horizontal one and a vertical one. The vertical one more closely resembles the mobile layout, with a "back" button on the left and a "next" button on the right, while the horizontal one features both buttons on the right. Thus far I've always seen the vertical layout when logged out and the horizontal layout when logged in, regardless of screen size, but I presume it may be possible to get the vertical layout on desktop with a small enough screen. The buttons have different selectors so I made sure to accommodate both.

I haven't yet handled the comment section. Comments aren't visible when logged out.

I've tested this in a logged-in local Chrome but not in a local Browsertrix.

Fixes #128 