### PR TITLE
facebook: rework comment handling

### DIFF
--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -16,11 +16,12 @@ const Q = {
   nextSlide:
     "//div[@aria-hidden='false']//div[@role='button' and not(@aria-hidden) and @aria-label]",
   commentList: ".//ul[(../h3) or (../h4)]",
-  commentMoreReplies: "./div[2]/div[1]/div[2]/div[@role='button']",
+  commentMoreReplies:
+    ".//span[contains(text(), 'View all')]/parent::span/parent::div[@role='button']",
   commentMoreComments:
-    "./following-sibling::div/div/div[2][@role='button'][./span/span]",
+    ".//span[text() = 'View more comments']/parent::span/parent::div[@role='button']",
   viewComments: ".//h4/..//div[@role='button']",
-  photoCommentList: "//ul[../h2]",
+  photoCommentList: "//h2[contains(text(), 'Comments')]/parent::div",
   commentFilterDropdown:
     "//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
   commentFilterAllComments:
@@ -263,11 +264,11 @@ export class FacebookTimelineBehavior
 
   async *iterComments(
     ctx: Context<FacebookState>,
-    commentRootUL: HTMLUListElement | null,
+    commentRoot: HTMLElement | null,
     maxExpands = 2,
   ) {
     const { getState, scrollIntoView, sleep, waitUnit, xpathNode } = ctx.Lib;
-    if (!commentRootUL) {
+    if (!commentRoot) {
       await sleep(waitUnit * 5);
       return;
     }
@@ -289,7 +290,10 @@ export class FacebookTimelineBehavior
       }
     }
 
-    let commentBlock = commentRootUL.firstElementChild;
+    let commentBlock = xpathNode(
+      "div[2]/div[1]",
+      commentRoot,
+    ) as HTMLElement | null;
     let lastBlock: Element | null = null;
 
     let count = 0;
@@ -300,17 +304,26 @@ export class FacebookTimelineBehavior
         scrollIntoView(commentBlock);
         await sleep(waitUnit * 2);
 
-        const moreReplies = xpathNode(
+        let moreReplies = xpathNode(
           Q.commentMoreReplies,
           commentBlock,
         ) as HTMLElement | null;
-        if (moreReplies) {
+        while (moreReplies) {
+          scrollIntoView(moreReplies);
+          // TODO: apply maxExpands per-comment or per-click?
           moreReplies.click();
           await sleep(waitUnit * 5);
+          // There can be additional "more replies" buttons
+          // within nested comment chains, so keep searching
+          // for them until we've fully exhausted them.
+          moreReplies = xpathNode(
+            Q.commentMoreReplies,
+            commentBlock,
+          ) as HTMLElement | null;
         }
 
         lastBlock = commentBlock;
-        commentBlock = lastBlock.nextElementSibling;
+        commentBlock = lastBlock.nextElementSibling as HTMLElement | null;
         count++;
       }
 
@@ -320,14 +333,14 @@ export class FacebookTimelineBehavior
 
       const moreButton = xpathNode(
         Q.commentMoreComments,
-        commentRootUL,
+        commentRoot,
       ) as HTMLElement | null;
       if (moreButton) {
         scrollIntoView(moreButton);
         moreButton.click();
         await sleep(waitUnit * 5);
         if (lastBlock) {
-          commentBlock = lastBlock.nextElementSibling;
+          commentBlock = lastBlock.nextElementSibling as HTMLElement | null;
           await sleep(waitUnit * 5);
         }
       }
@@ -375,7 +388,7 @@ export class FacebookTimelineBehavior
 
       yield getState(ctx, `Viewing photo ${window.location.href}`, "photos");
 
-      const root = xpathNode(Q.photoCommentList) as HTMLUListElement | null;
+      const root = xpathNode(Q.photoCommentList) as HTMLElement | null;
       yield* this.iterComments(ctx, root, 2);
 
       await sleep(waitUnit * 5);

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -139,11 +139,8 @@ export class FacebookTimelineBehavior
 
     //yield* this.viewPhotosOrVideos(ctx, post);
 
-    let commentRootUL = xpathNode(
-      Q.commentList,
-      post,
-    ) as HTMLUListElement | null;
-    if (!commentRootUL) {
+    let commentRoot = xpathNode(Q.commentList, post) as HTMLElement | null;
+    if (!commentRoot) {
       const viewCommentsButton = xpathNode(
         Q.viewComments,
         post,
@@ -152,9 +149,9 @@ export class FacebookTimelineBehavior
         viewCommentsButton.click();
         await sleep(waitUnit * 2);
       }
-      commentRootUL = xpathNode(Q.commentList, post) as HTMLUListElement | null;
+      commentRoot = xpathNode(Q.commentList, post) as HTMLElement | null;
     }
-    yield* this.iterComments(ctx, commentRootUL, maxExpands);
+    yield* this.iterComments(ctx, commentRoot, maxExpands);
 
     await sleep(waitUnit * 5);
   }
@@ -480,7 +477,7 @@ export class FacebookTimelineBehavior
 
     if (Q.isPhotoVideoPage.exec(window.location.href)) {
       ctx.state = { comments: 0 };
-      const root = xpathNode(Q.photoCommentList) as HTMLUListElement | null;
+      const root = xpathNode(Q.photoCommentList) as HTMLElement | null;
       yield* this.iterComments(ctx, root, 1000);
       return;
     }

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -16,16 +16,14 @@ const Q = {
   nextSlide:
     "//div[@aria-hidden='false']//div[@role='button' and not(@aria-hidden) and @aria-label]",
   commentList: ".//ul[(../h3) or (../h4)]",
-  commentMoreReplies:
-    ".//span[contains(text(), 'View all')]/parent::span/parent::div[@role='button']",
-  commentMoreComments:
-    ".//span[text() = 'View more comments']/parent::span/parent::div[@role='button']",
+  commentMoreReplies: ".//div[3]/div[2][@role='button']",
+  commentMoreComments: "./div/div[2]/div[2]/div[last()]//div[@role='button']",
   viewComments: ".//h4/..//div[@role='button']",
-  photoCommentList: "//h2[contains(text(), 'Comments')]/parent::div",
+  photoCommentList: "//div[@role='complementary']/div/div/div/div/div[3]/div",
   commentFilterDropdown:
     "//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
   commentFilterAllComments:
-    "//div[@role='menuitem']//span[contains(text(), 'All comments')]",
+    "//div[@role='menu']//div[@role='menuitem' and @tabindex=0]",
   firstPhotoThumbnail:
     "//div[@role='main']//div[3]//div[contains(@style, 'border-radius')]//div[contains(@style, 'max-width') and contains(@style, 'min-width')]//a[@role='link']",
   firstVideoThumbnail:

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -21,6 +21,10 @@ const Q = {
     "./following-sibling::div/div/div[2][@role='button'][./span/span]",
   viewComments: ".//h4/..//div[@role='button']",
   photoCommentList: "//ul[../h2]",
+  commentFilterDropdown:
+    "//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
+  commentFilterAllComments:
+    "//div[@role='menuitem']//span[contains(text(), 'All comments')]",
   firstPhotoThumbnail:
     "//div[@role='main']//div[3]//div[contains(@style, 'border-radius')]//div[contains(@style, 'max-width') and contains(@style, 'min-width')]//a[@role='link']",
   firstVideoThumbnail:
@@ -267,6 +271,24 @@ export class FacebookTimelineBehavior
       await sleep(waitUnit * 5);
       return;
     }
+
+    // If there's a comment filter, try to set it to "All Comments"
+    const filterDropdown = xpathNode(
+      Q.commentFilterDropdown,
+    ) as HTMLElement | null;
+    if (filterDropdown) {
+      filterDropdown.click();
+      const allComments = xpathNode(
+        Q.commentFilterAllComments,
+        filterDropdown,
+      ) as HTMLElement | null;
+      // Clicking this will automatically close the dropdown so we don't
+      // have to worry about manually closing it
+      if (allComments) {
+        allComments.click();
+      }
+    }
+
     let commentBlock = commentRootUL.firstElementChild;
     let lastBlock: Element | null = null;
 


### PR DESCRIPTION
The structure of the comment section has changed significantly since this was originally written. This makes a few changes to fix it and make sure we can see more content:

* Fixes the queries to locate the comment block for different page types.
* Facebook now displays a limited subset of comments by default with a "most relevant". We need to click through a dropdown to make sure we get all comments. Added a check for if that element exists and if it does, try to swap to "all comments" before we start clicking "more comments".
* In addition to the "more comments" button, there's now a "more replies" button within threads. If we don't click it, we only see the first few comments in a chain. This adds a loop to repeatedly click that "more replies" button until a given thread is fully expanded before moving onto the next thread.

refs #121 