### PR TITLE
facebook: update queries, add new features

### DIFF
--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -16,11 +16,12 @@ const Q = {
   nextSlide:
     "//div[@aria-hidden='false']//div[@role='button' and not(@aria-hidden) and @aria-label]",
   commentList: ".//ul[(../h3) or (../h4)]",
-  commentMoreReplies: "./div[2]/div[1]/div[2]/div[@role='button']",
+  commentMoreReplies:
+    ".//span[contains(text(), 'View all')]/parent::span/parent::div[@role='button']",
   commentMoreComments:
-    "./following-sibling::div/div/div[2][@role='button'][./span/span]",
+    ".//span[text() = 'View more comments']/parent::span/parent::div[@role='button']",
   viewComments: ".//h4/..//div[@role='button']",
-  photoCommentList: "//ul[../h2]",
+  photoCommentList: "//h2[contains(text(), 'Comments')]/parent::div",
   commentFilterDropdown:
     "//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
   commentFilterAllComments:
@@ -263,11 +264,11 @@ export class FacebookTimelineBehavior
 
   async *iterComments(
     ctx: Context<FacebookState>,
-    commentRootUL: HTMLUListElement | null,
+    commentRoot: HTMLElement | null,
     maxExpands = 2,
   ) {
     const { getState, scrollIntoView, sleep, waitUnit, xpathNode } = ctx.Lib;
-    if (!commentRootUL) {
+    if (!commentRoot) {
       await sleep(waitUnit * 5);
       return;
     }
@@ -289,7 +290,10 @@ export class FacebookTimelineBehavior
       }
     }
 
-    let commentBlock = commentRootUL.firstElementChild;
+    let commentBlock = xpathNode(
+      "div[2]/div[1]",
+      commentRoot,
+    ) as HTMLElement | null;
     let lastBlock: Element | null = null;
 
     let count = 0;
@@ -300,17 +304,26 @@ export class FacebookTimelineBehavior
         scrollIntoView(commentBlock);
         await sleep(waitUnit * 2);
 
-        const moreReplies = xpathNode(
+        let moreReplies = xpathNode(
           Q.commentMoreReplies,
           commentBlock,
         ) as HTMLElement | null;
-        if (moreReplies) {
+        while (moreReplies) {
+          scrollIntoView(moreReplies);
+          // TODO: apply maxExpands per-comment or per-click?
           moreReplies.click();
           await sleep(waitUnit * 5);
+          // There can be additional "more replies" buttons
+          // within nested comment chains, so keep searching
+          // for them until we've fully exhausted them.
+          moreReplies = xpathNode(
+            Q.commentMoreReplies,
+            commentBlock,
+          ) as HTMLElement | null;
         }
 
         lastBlock = commentBlock;
-        commentBlock = lastBlock.nextElementSibling;
+        commentBlock = lastBlock.nextElementSibling as HTMLElement | null;
         count++;
       }
 
@@ -320,14 +333,14 @@ export class FacebookTimelineBehavior
 
       const moreButton = xpathNode(
         Q.commentMoreComments,
-        commentRootUL,
+        commentRoot,
       ) as HTMLElement | null;
       if (moreButton) {
         scrollIntoView(moreButton);
         moreButton.click();
         await sleep(waitUnit * 5);
         if (lastBlock) {
-          commentBlock = lastBlock.nextElementSibling;
+          commentBlock = lastBlock.nextElementSibling as HTMLElement | null;
           await sleep(waitUnit * 5);
         }
       }
@@ -375,7 +388,7 @@ export class FacebookTimelineBehavior
 
       yield getState(ctx, `Viewing photo ${window.location.href}`, "photos");
 
-      const root = xpathNode(Q.photoCommentList) as HTMLUListElement | null;
+      const root = xpathNode(Q.photoCommentList) as HTMLElement | null;
       yield* this.iterComments(ctx, root, 2);
 
       await sleep(waitUnit * 5);

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -22,7 +22,7 @@ const Q = {
   viewComments: ".//h4/..//div[@role='button']",
   photoCommentList: "//ul[../h2]",
   firstPhotoThumbnail:
-    "//div[@role='main']//div[3]//div[contains(@style, 'border-radius')]//div[contains(@style, 'max-width') and contains(@style, 'min-width')]//a[@role='link']",
+    "//div[@role='main']//div[@data-pagelet='ProfileAppSection_0']//div[3]/div[1]/div[1]//a[@role='link']",
   firstVideoThumbnail:
     "//div[@role='main']//div[contains(@style, 'z-index')]/following-sibling::div/div/div/div[last()]//a[contains(@href, '/videos/') and @aria-hidden!='true']",
   firstVideoSimple:

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -139,11 +139,8 @@ export class FacebookTimelineBehavior
 
     //yield* this.viewPhotosOrVideos(ctx, post);
 
-    let commentRootUL = xpathNode(
-      Q.commentList,
-      post,
-    ) as HTMLUListElement | null;
-    if (!commentRootUL) {
+    let commentRoot = xpathNode(Q.commentList, post) as HTMLElement | null;
+    if (!commentRoot) {
       const viewCommentsButton = xpathNode(
         Q.viewComments,
         post,
@@ -152,9 +149,9 @@ export class FacebookTimelineBehavior
         viewCommentsButton.click();
         await sleep(waitUnit * 2);
       }
-      commentRootUL = xpathNode(Q.commentList, post) as HTMLUListElement | null;
+      commentRoot = xpathNode(Q.commentList, post) as HTMLElement | null;
     }
-    yield* this.iterComments(ctx, commentRootUL, maxExpands);
+    yield* this.iterComments(ctx, commentRoot, maxExpands);
 
     await sleep(waitUnit * 5);
   }
@@ -480,7 +477,7 @@ export class FacebookTimelineBehavior
 
     if (Q.isPhotoVideoPage.exec(window.location.href)) {
       ctx.state = { comments: 0 };
-      const root = xpathNode(Q.photoCommentList) as HTMLUListElement | null;
+      const root = xpathNode(Q.photoCommentList) as HTMLElement | null;
       yield* this.iterComments(ctx, root, 1000);
       return;
     }

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -21,6 +21,10 @@ const Q = {
     "./following-sibling::div/div/div[2][@role='button'][./span/span]",
   viewComments: ".//h4/..//div[@role='button']",
   photoCommentList: "//ul[../h2]",
+  commentFilterDropdown:
+    "//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
+  commentFilterAllComments:
+    "//div[@role='menuitem']//span[contains(text(), 'All comments')]",
   firstPhotoThumbnail:
     "//div[@role='main']//div[@data-pagelet='ProfileAppSection_0']//div[3]/div[1]/div[1]//a[@role='link']",
   firstVideoThumbnail:
@@ -267,6 +271,24 @@ export class FacebookTimelineBehavior
       await sleep(waitUnit * 5);
       return;
     }
+
+    // If there's a comment filter, try to set it to "All Comments"
+    const filterDropdown = xpathNode(
+      Q.commentFilterDropdown,
+    ) as HTMLElement | null;
+    if (filterDropdown) {
+      filterDropdown.click();
+      const allComments = xpathNode(
+        Q.commentFilterAllComments,
+        filterDropdown,
+      ) as HTMLElement | null;
+      // Clicking this will automatically close the dropdown so we don't
+      // have to worry about manually closing it
+      if (allComments) {
+        allComments.click();
+      }
+    }
+
     let commentBlock = commentRootUL.firstElementChild;
     let lastBlock: Element | null = null;
 

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -32,6 +32,13 @@ const Q = {
     "//div[@role='main']//div[contains(@style, 'z-index')]/following-sibling::div/div/div/div[last()]//a[contains(@href, '/videos/') and @aria-hidden!='true']",
   firstVideoSimple:
     "//div[@role='main']//a[contains(@href, '/videos/') and @aria-hidden!='true']",
+  firstReelThumbnail:
+    "//div[@role='main']//div[contains(@style, 'z-index')]/following-sibling::div/div/div/div[last()]//a[contains(@href, '/reel/')]",
+  firstReelSimple: "//div[@role='main']//a[contains(@href, '/reel/')]",
+  // Horizontal layout
+  nextReelCard: "//div[@role='main']/div[2]/div[2]/div[@role='button']",
+  // Vertical layout
+  nextReelCardAlt: "//div[@role='main']/div/div/div/div[3][@role='button']",
   mainVideo:
     "//div[@data-pagelet='root']//div[@role='dialog']//div[@role='main']//video",
   nextVideo:
@@ -39,11 +46,13 @@ const Q = {
   isPhotoVideoPage: /^.*facebook\.com\/[^/]+\/(photos|videos)\/.+/,
   isPhotosPage: /^.*facebook\.com\/[^/]+\/photos\/?($|\?)/,
   isVideosPage: /^.*facebook\.com\/[^/]+\/videos\/?($|\?)/,
+  isReelsPage: /^.*facebook\.com\/[^/]+\/reels\/?($|\?)/,
   pageLoadWaitUntil: "//div[@role='main']",
 };
 
 type FacebookState = Partial<{
   photos: number;
+  reels: number;
   videos: number;
   comments: number;
   posts: number;
@@ -454,6 +463,63 @@ export class FacebookTimelineBehavior
     }
   }
 
+  async *iterAllReels(ctx: Context<FacebookState>) {
+    const {
+      getState,
+      scrollIntoView,
+      sleep,
+      waitUnit,
+      waitUntil,
+      xpathNode,
+      xpathNodes,
+    } = ctx.Lib;
+
+    const videoLink = (xpathNode(Q.firstReelThumbnail) ||
+      xpathNode(Q.firstReelSimple)) as HTMLElement | null;
+
+    if (!videoLink) {
+      return;
+    }
+
+    scrollIntoView(videoLink);
+
+    let lastHref = window.location.href;
+    videoLink.click();
+    await waitUntil(() => window.location.href !== lastHref, waitUnit * 2);
+
+    await sleep(waitUnit * 10);
+
+    let nextButton = xpathNode(Q.nextReelCard) as HTMLElement | null;
+
+    while (nextButton) {
+      yield getState(ctx, "Viewing reel: " + window.location.href, "reels");
+      // wait for video to play, or 20s
+      await Promise.race([
+        waitUntil(() => {
+          for (const video of xpathNodes(
+            "//video",
+          ) as Generator<HTMLVideoElement>) {
+            if (video.readyState >= 3) {
+              return true;
+            }
+          }
+          return false;
+        }, waitUnit * 2),
+        sleep(20000),
+      ]);
+
+      await sleep(waitUnit * 10);
+
+      nextButton = xpathNode(Q.nextReelCard) as HTMLElement | null;
+
+      if (nextButton) {
+        nextButton.click();
+        lastHref = window.location.href;
+        await waitUntil(() => window.location.href !== lastHref, waitUnit * 2);
+      }
+    }
+  }
+
   async *run(ctx: Context<FacebookState>) {
     const { getState, sleep, xpathNode } = ctx.Lib;
     yield getState(ctx, "Starting...");
@@ -469,6 +535,12 @@ export class FacebookTimelineBehavior
     if (Q.isVideosPage.exec(window.location.href)) {
       ctx.state = { videos: 0, comments: 0 };
       yield* this.iterAllVideos(ctx);
+      return;
+    }
+
+    if (Q.isReelsPage.exec(window.location.href)) {
+      ctx.state = { reels: 0, comments: 0 };
+      yield* this.iterAllReels(ctx);
       return;
     }
 

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -37,7 +37,7 @@ const Q = {
   commentFilterAllComments:
     "//div[@role='menu']//div[@role='menuitem'][last()]",
   firstPhotoThumbnail:
-    "//div[@role='main']//div[@data-pagelet='ProfileAppSection_0']//div[3]/div[1]/div[1]//a[@role='link']",
+    "//div[@role='main']//div[4]/div/div/div/div//div[3]/div[1]/div[1]//a[@role='link']",
   firstVideoThumbnail:
     "//div[@role='main']//div[contains(@style, 'z-index')]/following-sibling::div/div/div/div[last()]//a[contains(@href, '/videos/') and @aria-hidden!='true']",
   firstVideoSimple:

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -10,7 +10,6 @@ const Q = {
   articleToPostList: "//div[@role='article']/../../../../div",
   photosOrVideos: `.//a[(contains(@href, '/photos/') or contains(@href, '/photo/?') or contains(@href, '/videos/')) and (starts-with(@href, '${window.location.origin}/') or starts-with(@href, '/'))]`,
   pagePostRootQuery: "//div[@role='dialog']",
-  pagePostQuery: ".//div[@role='article']",
   postQuery: ".//a[contains(@href, '/posts/')]",
   extraLabel: "//*[starts-with(text(), '+')]",
   nextSlideQuery:
@@ -21,16 +20,17 @@ const Q = {
   // distinct from comment lists located elsewhere
   commentList: ".//ul[(../h3) or (../h4)]",
   // Single page post from an organization page
-  singlePostCommentList:
-    "./div/div/div/div/div/div[2]/div/div/div[4]/div/div/div[2]/div[2]",
+  singlePostCommentList: ".//div[2]//div[4]/div/div/div[2]/div[2]",
   // Single page post from a group page
   groupPostCommentList: "./div//div[2]/div/div/div[4]/div/div/div[2]/div[2]",
   commentMoreReplies: ".//div[2][@role='button']",
   commentMoreComments: "./div/div[2]/div[2]/div[last()]//div[@role='button']",
   viewComments: ".//h4/..//div[@role='button']",
   photoCommentList: "//div[@role='complementary']/div/div/div/div/div[3]/div",
+  // Checking for the existence of the span here helps distinguish this from
+  // other divs that also have role=button and aria-haspopup=menu
   commentFilterDropdown:
-    "//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
+    ".//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
   commentFilterAllComments:
     "//div[@role='menu']//div[@role='menuitem' and @tabindex=0]",
   firstPhotoThumbnail:
@@ -145,8 +145,7 @@ export class FacebookTimelineBehavior
   async *handleSinglePost(ctx: Context<FacebookState>) {
     const { xpathNode } = ctx.Lib;
 
-    const feed = xpathNode(Q.pagePostRootQuery) as Element | null;
-    const post = xpathNode(Q.pagePostQuery, feed) as Element | null;
+    const post = xpathNode(Q.pagePostRootQuery) as Element | null;
 
     yield* this.viewPost(ctx, post, Q.singlePostCommentList);
   }
@@ -196,7 +195,7 @@ export class FacebookTimelineBehavior
       }
       commentRoot = xpathNode(commentQuery, post) as HTMLElement | null;
     }
-    yield* this.iterComments(ctx, commentRoot, maxExpands);
+    yield* this.iterComments(ctx, post, commentRoot, maxExpands);
 
     await sleep(waitUnit * 5);
   }
@@ -306,6 +305,7 @@ export class FacebookTimelineBehavior
 
   async *iterComments(
     ctx: Context<FacebookState>,
+    post: Element | HTMLElement | null,
     commentRoot: HTMLElement | null,
     maxExpands = 2,
   ) {
@@ -318,6 +318,7 @@ export class FacebookTimelineBehavior
     // If there's a comment filter, try to set it to "All Comments"
     const filterDropdown = xpathNode(
       Q.commentFilterDropdown,
+      post,
     ) as HTMLElement | null;
     if (filterDropdown) {
       filterDropdown.click();
@@ -431,7 +432,7 @@ export class FacebookTimelineBehavior
       yield getState(ctx, `Viewing photo ${window.location.href}`, "photos");
 
       const root = xpathNode(Q.photoCommentList) as HTMLElement | null;
-      yield* this.iterComments(ctx, root, 2);
+      yield* this.iterComments(ctx, root, root, 2);
 
       await sleep(waitUnit * 5);
     }
@@ -610,7 +611,7 @@ export class FacebookTimelineBehavior
     if (Q.isPhotoVideoPage.exec(window.location.href)) {
       ctx.state = { comments: 0 };
       const root = xpathNode(Q.photoCommentList) as HTMLElement | null;
-      yield* this.iterComments(ctx, root, 1000);
+      yield* this.iterComments(ctx, root, root, 1000);
       return;
     }
 

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -685,12 +685,14 @@ export class FacebookTimelineBehavior
       ctx.state = { comments: 0 };
       yield getState(ctx, "Viewing single group post");
       yield* this.handleGroupPost(ctx);
+      return;
     }
 
     if (Q.isSinglePost.exec(window.location.href)) {
       ctx.state = { comments: 0 };
       yield getState(ctx, "Viewing single post");
       yield* this.handleSinglePost(ctx);
+      return;
     }
 
     if (Q.isPhotoVideoPage.exec(window.location.href)) {

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -48,6 +48,7 @@ const Q = {
   isVideosPage: /^.*facebook\.com\/[^/]+\/videos\/?($|\?)/,
   isReelsPage: /^.*facebook\.com\/[^/]+\/reels\/?($|\?)/,
   pageLoadWaitUntil: "//div[@role='main']",
+  loginModal: "//div[@role='dialog']//div[@role='button']",
 };
 
 type FacebookState = Partial<{
@@ -527,6 +528,13 @@ export class FacebookTimelineBehavior
     yield getState(ctx, "Starting...");
 
     await sleep(2000);
+
+    // If we're logged out, make sure to click the close button
+    // before trying to interact with the page in any other way.
+    const loginModal = xpathNode(Q.loginModal) as HTMLElement | null;
+    if (loginModal) {
+      loginModal.click();
+    }
 
     if (Q.isPhotosPage.exec(window.location.href)) {
       ctx.state = { photos: 0, comments: 0 };

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -489,7 +489,8 @@ export class FacebookTimelineBehavior
 
     await sleep(waitUnit * 10);
 
-    let nextButton = xpathNode(Q.nextReelCard) as HTMLElement | null;
+    let nextButton = (xpathNode(Q.nextReelCard) ||
+      xpathNode(Q.nextReelCardAlt)) as HTMLElement | null;
 
     while (nextButton) {
       yield getState(ctx, "Viewing reel: " + window.location.href, "reels");
@@ -510,7 +511,8 @@ export class FacebookTimelineBehavior
 
       await sleep(waitUnit * 10);
 
-      nextButton = xpathNode(Q.nextReelCard) as HTMLElement | null;
+      nextButton = (xpathNode(Q.nextReelCard) ||
+        xpathNode(Q.nextReelCardAlt)) as HTMLElement | null;
 
       if (nextButton) {
         nextButton.click();

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -18,16 +18,14 @@ const Q = {
   // Specifically the comment list from posts seen in a timeline,
   // distinct from comment lists located elsewhere
   commentList: ".//ul[(../h3) or (../h4)]",
-  commentMoreReplies:
-    ".//span[contains(text(), 'View all')]/parent::span/parent::div[@role='button']",
-  commentMoreComments:
-    ".//span[text() = 'View more comments']/parent::span/parent::div[@role='button']",
+  commentMoreReplies: ".//div[3]/div[2][@role='button']",
+  commentMoreComments: "./div/div[2]/div[2]/div[last()]//div[@role='button']",
   viewComments: ".//h4/..//div[@role='button']",
-  photoCommentList: "//h2[contains(text(), 'Comments')]/parent::div",
+  photoCommentList: "//div[@role='complementary']/div/div/div/div/div[3]/div",
   commentFilterDropdown:
     "//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
   commentFilterAllComments:
-    "//div[@role='menuitem']//span[contains(text(), 'All comments')]",
+    "//div[@role='menu']//div[@role='menuitem' and @tabindex=0]",
   firstPhotoThumbnail:
     "//div[@role='main']//div[@data-pagelet='ProfileAppSection_0']//div[3]/div[1]/div[1]//a[@role='link']",
   firstVideoThumbnail:

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -448,7 +448,7 @@ export class FacebookTimelineBehavior
     scrollIntoView(firstPhoto);
 
     firstPhoto.click();
-    await sleep(waitUnit * 5);
+    await sleep(waitUnit * 20);
     await waitUntil(() => window.location.href !== lastHref, waitUnit * 2);
 
     let nextSlideButton: HTMLElement | null = null;

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -124,11 +124,7 @@ export class FacebookTimelineBehavior
       for (const post of feeds) {
         yield getState(ctx, "Viewing post from feed");
         scrollIntoView(post);
-        yield* this.viewPost(
-          ctx,
-          xpathNode(Q.article, post) as Element | null,
-          Q.commentList,
-        );
+        yield* this.viewPost(ctx, post, Q.commentList);
         await sleep(waitUnit * 20);
       }
 
@@ -144,11 +140,7 @@ export class FacebookTimelineBehavior
         for (const post of feeds) {
           yield getState(ctx, "Viewing post from feed");
           scrollIntoView(post);
-          yield* this.viewPost(
-            ctx,
-            xpathNode(Q.article, post) as Element | null,
-            Q.commentList,
-          );
+          yield* this.viewPost(ctx, post, Q.commentList);
           await sleep(waitUnit * 20);
         }
         lastSeen = feeds.at(-1);

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -98,8 +98,15 @@ export class FacebookTimelineBehavior
   }
 
   async *iterPostFeeds(ctx: Context<FacebookState>) {
-    const { iterChildElem, getState, waitUnit, xpathNode, xpathNodes } =
-      ctx.Lib;
+    const {
+      iterChildElem,
+      getState,
+      scrollIntoView,
+      sleep,
+      waitUnit,
+      xpathNode,
+      xpathNodes,
+    } = ctx.Lib;
     let feeds = Array.from(xpathNodes(Q.feed)) as Element[];
     if (feeds.length) {
       for (const feed of feeds) {
@@ -112,16 +119,17 @@ export class FacebookTimelineBehavior
         }
       }
     } else if (
-      (feeds = Array.from(xpathNodes(Q.articleList)) as Element[]) &&
-      feeds.length
+      (feeds = Array.from(xpathNodes(Q.articleList)) as Element[]).length
     ) {
       for (const post of feeds) {
         yield getState(ctx, "Viewing post from feed");
+        scrollIntoView(post);
         yield* this.viewPost(
           ctx,
           xpathNode(Q.article, post) as Element | null,
           Q.commentList,
         );
+        await sleep(waitUnit * 20);
       }
 
       // Keep looping until we run out of posts in the timeline
@@ -135,11 +143,13 @@ export class FacebookTimelineBehavior
 
         for (const post of feeds) {
           yield getState(ctx, "Viewing post from feed");
+          scrollIntoView(post);
           yield* this.viewPost(
             ctx,
             xpathNode(Q.article, post) as Element | null,
             Q.commentList,
           );
+          await sleep(waitUnit * 20);
         }
         lastSeen = feeds.at(-1);
       }

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -62,7 +62,10 @@ const Q = {
   // Post from a group
   isSingleGroupPost: /^.*facebook\.com\/groups\/[^/]+\/posts\/[^/]+\/?($|\?)/,
   pageLoadWaitUntil: "//div[@role='main']",
-  loginModal: "//div[@role='dialog']//div[@role='button']",
+  // Limit query to only modals with the login_popup_cta_form form child in order
+  // to avoid grabbing unrelated modals, like pop-up posts
+  loginModal:
+    "//div[@role='dialog'][.//form[@id='login_popup_cta_form']]//div[@role='button']",
 };
 
 type FacebookState = Partial<{

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -177,7 +177,7 @@ export class FacebookTimelineBehavior
       feed,
     ) as Element | null;
 
-    yield* this.viewPost(ctx, post, Q.groupPostCommentList);
+    yield* this.viewPost(ctx, post, Q.groupPostCommentList, 1000);
   }
 
   async *handleSinglePost(ctx: Context<FacebookState>) {
@@ -185,7 +185,7 @@ export class FacebookTimelineBehavior
 
     const post = xpathNode(Q.pagePostRootQuery) as Element | null;
 
-    yield* this.viewPost(ctx, post, Q.singlePostCommentList);
+    yield* this.viewPost(ctx, post, Q.singlePostCommentList, 1000);
   }
 
   async *viewPost(
@@ -233,7 +233,7 @@ export class FacebookTimelineBehavior
       }
       commentRoot = xpathNode(commentQuery, post) as HTMLElement | null;
     }
-    yield* this.iterComments(ctx, post, commentRoot, maxExpands);
+    yield* this.iterInfiniteScrollComments(ctx, post, commentRoot, maxExpands);
 
     await sleep(waitUnit * 5);
   }
@@ -341,7 +341,9 @@ export class FacebookTimelineBehavior
     }
   }
 
-  async *iterComments(
+  // Used on some logged-in pages and all logged-out pages;
+  // additional comments are loaded by clicking a button.
+  async *iterPaginatedComments(
     ctx: Context<FacebookState>,
     post: Element | HTMLElement | null,
     commentRoot: HTMLElement | null,
@@ -434,6 +436,45 @@ export class FacebookTimelineBehavior
     await sleep(waitUnit * 2);
   }
 
+  // Used by certain logged-in pages; there's no way to explicitly
+  // expand comments, they just load in as you scroll.
+  async *iterInfiniteScrollComments(
+    ctx: Context<FacebookState>,
+    post: Element | HTMLElement | null,
+    commentRoot: HTMLElement | null,
+    maxExpands = 2,
+  ) {
+    const { getState, scrollIntoView, sleep, waitUnit } = ctx.Lib;
+
+    if (!commentRoot) {
+      yield getState(ctx, "Comment root is null; returning");
+      return;
+    }
+
+    let lastFinalComment =
+      commentRoot.children[commentRoot.children.length - 1];
+
+    for (let i = 0; i < maxExpands; i++) {
+      yield getState(
+        ctx,
+        "Scrolling to bottom of comments to load more",
+        "comments",
+      );
+      scrollIntoView(lastFinalComment);
+      await sleep(waitUnit * 20);
+
+      // Looks like we've run out of comments, so stop iterating
+      if (
+        commentRoot.children[commentRoot.children.length - 1] ===
+        lastFinalComment
+      ) {
+        break;
+      }
+
+      lastFinalComment = commentRoot.children[commentRoot.children.length - 1];
+    }
+  }
+
   async *iterPhotoSlideShow(ctx: Context<FacebookState>) {
     const { getState, scrollIntoView, sleep, waitUnit, waitUntil, xpathNode } =
       ctx.Lib;
@@ -474,7 +515,9 @@ export class FacebookTimelineBehavior
       yield getState(ctx, `Viewing photo ${window.location.href}`, "photos");
 
       const root = xpathNode(Q.photoCommentList) as HTMLElement | null;
-      yield* this.iterComments(ctx, root, root, 2);
+      // Photo pages seen in the slideshow always use paginated comments,
+      // both when signed in and when not.
+      yield* this.iterPaginatedComments(ctx, root, root, 2);
 
       await sleep(waitUnit * 5);
     }
@@ -653,7 +696,14 @@ export class FacebookTimelineBehavior
     if (Q.isPhotoVideoPage.exec(window.location.href)) {
       ctx.state = { comments: 0 };
       const root = xpathNode(Q.photoCommentList) as HTMLElement | null;
-      yield* this.iterComments(ctx, root, root, 1000);
+      // Single photo pages use the infinite scroll comment widget
+      // when logged in, but the paginated comment widget when
+      // logged out.
+      if (this.isLoggedIn()) {
+        yield* this.iterInfiniteScrollComments(ctx, root, root, 1000);
+      } else {
+        yield* this.iterPaginatedComments(ctx, root, root, 1000);
+      }
       return;
     }
 

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -32,7 +32,7 @@ const Q = {
   commentFilterDropdown:
     ".//div[@aria-haspopup='menu' and @role='button']/span/parent::div",
   commentFilterAllComments:
-    "//div[@role='menu']//div[@role='menuitem' and @tabindex=0]",
+    "//div[@role='menu']//div[@role='menuitem'][last()]",
   firstPhotoThumbnail:
     "//div[@role='main']//div[@data-pagelet='ProfileAppSection_0']//div[3]/div[1]/div[1]//a[@role='link']",
   firstVideoThumbnail:
@@ -321,15 +321,19 @@ export class FacebookTimelineBehavior
       post,
     ) as HTMLElement | null;
     if (filterDropdown) {
+      yield getState(ctx, "Switching to 'All comments'");
       filterDropdown.click();
+      await sleep(waitUnit * 20);
+
       const allComments = xpathNode(
         Q.commentFilterAllComments,
-        filterDropdown,
       ) as HTMLElement | null;
       // Clicking this will automatically close the dropdown so we don't
       // have to worry about manually closing it
       if (allComments) {
+        yield getState(ctx, "Clicking 'All comments' button");
         allComments.click();
+        await sleep(waitUnit * 20);
       }
     }
 

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -9,6 +9,8 @@ const Q = {
     "//div[@data-pagelet='page']//div[@data-pagelet='ProfileTimeline']",
   articleToPostList: "//div[@role='article']/../../../../div",
   photosOrVideos: `.//a[(contains(@href, '/photos/') or contains(@href, '/photo/?') or contains(@href, '/videos/')) and (starts-with(@href, '${window.location.origin}/') or starts-with(@href, '/'))]`,
+  pagePostRootQuery: "//div[@role='dialog']",
+  pagePostQuery: ".//div[@role='article']",
   postQuery: ".//a[contains(@href, '/posts/')]",
   extraLabel: "//*[starts-with(text(), '+')]",
   nextSlideQuery:
@@ -18,7 +20,12 @@ const Q = {
   // Specifically the comment list from posts seen in a timeline,
   // distinct from comment lists located elsewhere
   commentList: ".//ul[(../h3) or (../h4)]",
-  commentMoreReplies: ".//div[3]/div[2][@role='button']",
+  // Single page post from an organization page
+  singlePostCommentList:
+    "./div/div/div/div/div/div[2]/div/div/div[4]/div/div/div[2]/div[2]",
+  // Single page post from a group page
+  groupPostCommentList: "./div//div[2]/div/div/div[4]/div/div/div[2]/div[2]",
+  commentMoreReplies: ".//div[2][@role='button']",
   commentMoreComments: "./div/div[2]/div[2]/div[last()]//div[@role='button']",
   viewComments: ".//h4/..//div[@role='button']",
   photoCommentList: "//div[@role='complementary']/div/div/div/div/div[3]/div",
@@ -47,6 +54,10 @@ const Q = {
   isPhotosPage: /^.*facebook\.com\/[^/]+\/photos\/?($|\?)/,
   isVideosPage: /^.*facebook\.com\/[^/]+\/videos\/?($|\?)/,
   isReelsPage: /^.*facebook\.com\/[^/]+\/reels\/?($|\?)/,
+  // Post from an organization/etc. page
+  isSinglePost: /^.*facebook\.com\/\w+\/posts\/[^/]+\/?($|\?)/,
+  // Post from a group
+  isSingleGroupPost: /^.*facebook\.com\/groups\/[^/]+\/posts\/[^/]+\/?($|\?)/,
   pageLoadWaitUntil: "//div[@role='main']",
   loginModal: "//div[@role='dialog']//div[@role='button']",
 };
@@ -92,6 +103,7 @@ export class FacebookTimelineBehavior
           yield* this.viewPost(
             ctx,
             xpathNode(Q.article, post) as Element | null,
+            Q.commentList,
           );
         }
       }
@@ -105,7 +117,11 @@ export class FacebookTimelineBehavior
       }
 
       for await (const post of iterChildElem(feed, waitUnit, waitUnit * 10)) {
-        yield* this.viewPost(ctx, xpathNode(Q.article, post) as Element);
+        yield* this.viewPost(
+          ctx,
+          xpathNode(Q.article, post) as Element,
+          Q.commentList,
+        );
       }
     }
 
@@ -114,9 +130,31 @@ export class FacebookTimelineBehavior
     }
   }
 
+  async *handleGroupPost(ctx: Context<FacebookState>) {
+    const { xpathNode } = ctx.Lib;
+
+    const feed = xpathNode(Q.feed) as Element;
+    const post = xpathNode(
+      "./div[@role='presentation']",
+      feed,
+    ) as Element | null;
+
+    yield* this.viewPost(ctx, post, Q.groupPostCommentList);
+  }
+
+  async *handleSinglePost(ctx: Context<FacebookState>) {
+    const { xpathNode } = ctx.Lib;
+
+    const feed = xpathNode(Q.pagePostRootQuery) as Element | null;
+    const post = xpathNode(Q.pagePostQuery, feed) as Element | null;
+
+    yield* this.viewPost(ctx, post, Q.singlePostCommentList);
+  }
+
   async *viewPost(
     ctx: Context<FacebookState>,
     post: Element | null,
+    commentQuery: string,
     maxExpands = 2,
   ) {
     const { getState, scrollIntoView, sleep, waitUnit, xpathNode } = ctx.Lib;
@@ -146,7 +184,7 @@ export class FacebookTimelineBehavior
 
     //yield* this.viewPhotosOrVideos(ctx, post);
 
-    let commentRoot = xpathNode(Q.commentList, post) as HTMLElement | null;
+    let commentRoot = xpathNode(commentQuery, post) as HTMLElement | null;
     if (!commentRoot) {
       const viewCommentsButton = xpathNode(
         Q.viewComments,
@@ -156,7 +194,7 @@ export class FacebookTimelineBehavior
         viewCommentsButton.click();
         await sleep(waitUnit * 2);
       }
-      commentRoot = xpathNode(Q.commentList, post) as HTMLElement | null;
+      commentRoot = xpathNode(commentQuery, post) as HTMLElement | null;
     }
     yield* this.iterComments(ctx, commentRoot, maxExpands);
 
@@ -555,6 +593,18 @@ export class FacebookTimelineBehavior
       yield getState(ctx, "Iterating reels");
       yield* this.iterAllReels(ctx);
       return;
+    }
+
+    if (Q.isSingleGroupPost.exec(window.location.href)) {
+      ctx.state = { comments: 0 };
+      yield getState(ctx, "Viewing single group post");
+      yield* this.handleGroupPost(ctx);
+    }
+
+    if (Q.isSinglePost.exec(window.location.href)) {
+      ctx.state = { comments: 0 };
+      yield getState(ctx, "Viewing single post");
+      yield* this.handleSinglePost(ctx);
     }
 
     if (Q.isPhotoVideoPage.exec(window.location.href)) {

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -661,6 +661,11 @@ export class FacebookTimelineBehavior
     yield* this.iterPostFeeds(ctx);
   }
 
+  isLoggedIn() {
+    // Login form only appears for logged-out users
+    return !document.querySelector("form[id='login_form']");
+  }
+
   async awaitPageLoad(ctx: Context<FacebookState>) {
     const { Lib, log } = ctx;
     const { assertContentValid, waitUntilNode } = Lib;
@@ -669,9 +674,6 @@ export class FacebookTimelineBehavior
 
     await waitUntilNode(Q.pageLoadWaitUntil, document, null, 10000);
 
-    assertContentValid(
-      () => !!document.querySelector("div[aria-label*='Account Controls' i]"),
-      "not_logged_in",
-    );
+    assertContentValid(() => !this.isLoggedIn(), "not_logged_in");
   }
 }

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -8,6 +8,9 @@ const Q = {
   pageletProfilePostList:
     "//div[@data-pagelet='page']//div[@data-pagelet='ProfileTimeline']",
   articleToPostList: "//div[@role='article']/../../../../div",
+  // In the feed view, comments also have @role='article' but additionally
+  // have an @aria-label that actual posts don't have.
+  articleList: "//div[@role='article' and not(@aria-label)]",
   photosOrVideos: `.//a[(contains(@href, '/photos/') or contains(@href, '/photo/?') or contains(@href, '/videos/')) and (starts-with(@href, '${window.location.origin}/') or starts-with(@href, '/'))]`,
   pagePostRootQuery: "//div[@role='dialog']",
   postQuery: ".//a[contains(@href, '/posts/')]",
@@ -95,8 +98,9 @@ export class FacebookTimelineBehavior
   }
 
   async *iterPostFeeds(ctx: Context<FacebookState>) {
-    const { iterChildElem, waitUnit, xpathNode, xpathNodes } = ctx.Lib;
-    const feeds = Array.from(xpathNodes(Q.feed)) as Element[];
+    const { iterChildElem, getState, waitUnit, xpathNode, xpathNodes } =
+      ctx.Lib;
+    let feeds = Array.from(xpathNodes(Q.feed)) as Element[];
     if (feeds.length) {
       for (const feed of feeds) {
         for await (const post of iterChildElem(feed, waitUnit, waitUnit * 10)) {
@@ -106,6 +110,38 @@ export class FacebookTimelineBehavior
             Q.commentList,
           );
         }
+      }
+    } else if (
+      (feeds = Array.from(xpathNodes(Q.articleList)) as Element[]) &&
+      feeds.length
+    ) {
+      for (const post of feeds) {
+        yield getState(ctx, "Viewing post from feed");
+        yield* this.viewPost(
+          ctx,
+          xpathNode(Q.article, post) as Element | null,
+          Q.commentList,
+        );
+      }
+
+      // Keep looping until we run out of posts in the timeline
+      // or hit a limit
+      let lastSeen = feeds.at(-1);
+      for (let i = 0; i < 50; i++) {
+        feeds = Array.from(xpathNodes(Q.articleList)) as Element[];
+        if (feeds[0] == lastSeen) {
+          break;
+        }
+
+        for (const post of feeds) {
+          yield getState(ctx, "Viewing post from feed");
+          yield* this.viewPost(
+            ctx,
+            xpathNode(Q.article, post) as Element | null,
+            Q.commentList,
+          );
+        }
+        lastSeen = feeds.at(-1);
       }
     } else {
       const feed = (xpathNode(Q.pageletPostList) ||

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -15,6 +15,8 @@ const Q = {
     "//div[@data-name='media-viewer-nav-container']/div[@data-visualcompletion][2]//div[@role='button']",
   nextSlide:
     "//div[@aria-hidden='false']//div[@role='button' and not(@aria-hidden) and @aria-label]",
+  // Specifically the comment list from posts seen in a timeline,
+  // distinct from comment lists located elsewhere
   commentList: ".//ul[(../h3) or (../h4)]",
   commentMoreReplies:
     ".//span[contains(text(), 'View all')]/parent::span/parent::div[@role='button']",

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -530,18 +530,21 @@ export class FacebookTimelineBehavior
 
     if (Q.isPhotosPage.exec(window.location.href)) {
       ctx.state = { photos: 0, comments: 0 };
+      yield getState(ctx, "Iterating photos");
       yield* this.iterPhotoSlideShow(ctx);
       return;
     }
 
     if (Q.isVideosPage.exec(window.location.href)) {
       ctx.state = { videos: 0, comments: 0 };
+      yield getState(ctx, "Iterating videos");
       yield* this.iterAllVideos(ctx);
       return;
     }
 
     if (Q.isReelsPage.exec(window.location.href)) {
       ctx.state = { reels: 0, comments: 0 };
+      yield getState(ctx, "Iterating reels");
       yield* this.iterAllReels(ctx);
       return;
     }

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -58,10 +58,7 @@ export class FacebookTimelineBehavior
   static id = "Facebook" as const;
 
   static isMatch() {
-    // match just for posts for now
-    return !!window.location.href.match(
-      /https:\/\/(www\.)?facebook\.com\/.*\/posts\//,
-    );
+    return !!window.location.href.match(/https:\/\/(www\.)?facebook\.com\//);
   }
 
   static init() {


### PR DESCRIPTION
This replaces the separate PRs I had for different parts of the Facebook behaviour.

### Reels

This adds support for visiting reels pages. Similar to photos, it starts from the `/page/reels/` URL, clicks the first thumbnail, and then iterates through reels by clicking the next button. Currently, I haven't set a limit on how many videos it should try to visit; it will just keep going until it hits the configured timeout.

There are two different reels layouts that can be seen on desktop - a horizontal one and a vertical one. The vertical one more closely resembles the mobile layout, with a "back" button on the left and a "next" button on the right, while the horizontal one features both buttons on the right. Thus far I've always seen the vertical layout when logged out and the horizontal layout when logged in, regardless of screen size, but I presume it may be possible to get the vertical layout on desktop with a small enough screen. The buttons have different selectors so I made sure to accommodate both.

This is confirmed to be correctly navigating reels in Browsertrix. Playback seems to not always work; I suspect that replay may be in a smaller window that's triggering it to try to replay lower-resolution copies, while capture had only captured the high-resolution copies. We need to investigate.

I haven't yet handled the comment section. Comments aren't visible when logged out.

Fixes #128 

### Photo pages

We're now correctly iterating through all photos on a profile. We're able to capture a good number of photos even when logged out.

refs #121 

### Comments

The structure of the comment section has changed significantly since this was originally written. This makes a few changes to fix it and make sure we can see more content:

* Fixes the queries to locate the comment block for different page types.
* Facebook now displays a limited subset of comments by default with a "most relevant". We need to click through a dropdown to make sure we get all comments. Added a check for if that element exists and if it does, try to swap to "all comments" before we start clicking "more comments".
* In addition to the "more comments" button, there's now a "more replies" button within threads. If we don't click it, we only see the first few comments in a chain. This adds a loop to repeatedly click that "more replies" button until a given thread is fully expanded before moving onto the next thread.

### Timelines

I've fixed browsing timelines. It's been tested on an organization page. The current version has a fairly arbitrary limit set on how far we'll browse, so we'll want to think about that. We could decide to simply continue until the behaviour times out.

I've left the old queries in place, but very likely some of these can be cleaned up since I suspect not all of them still work. We may want to audit if there are any timeline pages where they still do anything.

### Single posts

We're now capturing single posts correctly. It's been tested with groups and organizations.