### PR TITLE
instagram: add stories

### DIFF
--- a/src/site/instagram.ts
+++ b/src/site/instagram.ts
@@ -30,6 +30,15 @@ const Q = {
   // visible indefinitely instead of expiring after a period of time
   // like the ones accessible from the avatar.
   storiesHighlights: "//div[@role='presentation']//ul//li//a",
+  // The button to access a direct message from within a story.
+  // This is only visible when logged-in (a different button is displayed
+  // on stories that can be viewed logged-out), so this can be used as a
+  // proxy for whether the user is logged in or not.
+  // In testing, this aria-label seems stable across languages, even
+  // languages that don't use Roman script. This label always at least
+  // starts with the string "Direct".
+  storiesDirectMessageButton:
+    "//*[local-name() = 'svg' and starts-with(@aria-label, 'Direct')]",
   userPage: /^\/([^/]+)\/?$/,
 };
 
@@ -360,9 +369,13 @@ export class InstagramPostsBehavior
 
     await waitUntilNode(Q.pageLoadWaitUntil, document, null, 10000);
 
-    assertContentValid(
-      () => !!document.querySelector("*[aria-label='New post']"),
-      "not_logged_in",
-    );
+    // It's currently difficult to determine login state on stories,
+    // so we skip this check there.
+    if (!window.location.pathname.startsWith("/stories")) {
+      assertContentValid(
+        () => !!document.querySelector("*[aria-label='New post']"),
+        "not_logged_in",
+      );
+    }
   }
 }

--- a/src/site/instagram.ts
+++ b/src/site/instagram.ts
@@ -24,6 +24,12 @@ const Q = {
   storiesHalo: "//section/div/span/div/div[@role='button']",
   storiesViewStoryButton:
     "//section/div[1]/div/div/div/div/div[2]/div/div[3]/div",
+  // A separate list of stories that appears underneath the user's bio.
+  // These are separate from the ones visible from the user avatar;
+  // they're "highlights", which each get their own URL and which are
+  // visible indefinitely instead of expiring after a period of time
+  // like the ones accessible from the avatar.
+  storiesHighlights: "//div[@role='presentation']//ul//li//a",
   userPage: /^\/([^/]+)\/?$/,
 };
 
@@ -284,8 +290,15 @@ export class InstagramPostsBehavior
       return;
     }
 
-    const { addLink, getState, scrollIntoView, sleep, waitUnit, xpathNode } =
-      ctx.Lib;
+    const {
+      addLink,
+      getState,
+      scrollIntoView,
+      sleep,
+      waitUnit,
+      xpathNode,
+      xpathNodes,
+    } = ctx.Lib;
 
     // If we're navigating a profile page, queue up this user's stories
     const match = Q.userPage.exec(window.location.pathname);
@@ -298,6 +311,20 @@ export class InstagramPostsBehavior
         const userName = match[1];
         await addLink(`https://instagram.com/stories/${userName}/`);
       }
+    }
+
+    // This second set of stories is the highlights, which are accessible
+    // from a separate set of links below the user profile.
+    // Unlike the stories above, these are accessible via links.
+    for (const story of xpathNodes(
+      Q.storiesHighlights,
+    ) as Generator<HTMLLinkElement>) {
+      yield getState(
+        ctx,
+        "Adding link to story highlight: " + story.href,
+        "stories",
+      );
+      await addLink(story.href);
     }
 
     for await (const row of this.iterRow(ctx)) {

--- a/src/site/instagram.ts
+++ b/src/site/instagram.ts
@@ -121,50 +121,6 @@ export class InstagramPostsBehavior
     }
   }
 
-  async *viewStandalonePost(ctx: Context<InstagramState>, origLoc: string) {
-    const { getState, sleep, waitUnit, waitUntil, xpathNode, xpathString } =
-      ctx.Lib;
-    const root = xpathNode(Q.rootPath) as HTMLElement | null;
-
-    if (!root?.firstElementChild) {
-      return;
-    }
-
-    const firstPostHref = xpathString(
-      Q.childMatchSelect,
-      root.firstElementChild,
-    );
-
-    yield getState(
-      ctx,
-      "Loading single post view for first post: " + firstPostHref,
-    );
-
-    window.history.replaceState({}, "", firstPostHref);
-    window.dispatchEvent(new PopStateEvent("popstate", { state: {} }));
-
-    let root2: Node | null = null;
-    let root3: Node | null = null;
-
-    await sleep(waitUnit * 5);
-
-    await waitUntil(
-      () => !!((root2 = xpathNode(Q.rootPath)) !== root && root2),
-      waitUnit * 5,
-    );
-
-    await sleep(waitUnit * 5);
-
-    window.history.replaceState({}, "", origLoc);
-    window.dispatchEvent(new PopStateEvent("popstate", { state: {} }));
-
-    await waitUntil(
-      () => !!((root3 = xpathNode(Q.rootPath)) !== root2 && root3),
-      waitUnit * 5,
-    );
-    //}
-  }
-
   async *iterSubposts(ctx: Context<InstagramState>, profileView: boolean) {
     const queries = profileView ? Q : PageQ;
 
@@ -299,9 +255,6 @@ export class InstagramPostsBehavior
     }
 
     const { getState, scrollIntoView, sleep, waitUnit, xpathNode } = ctx.Lib;
-    //const origLoc = window.location.href;
-
-    //yield* this.viewStandalonePost(ctx, origLoc);
 
     for await (const row of this.iterRow(ctx)) {
       scrollIntoView(row);

--- a/src/site/instagram.ts
+++ b/src/site/instagram.ts
@@ -271,21 +271,24 @@ export class InstagramPostsBehavior
   }
 
   async *handleStories(ctx: Context<InstagramState>) {
-    const { getState, xpathNode } = ctx.Lib;
+    const { getState, sleep, xpathNode } = ctx.Lib;
 
     yield getState(ctx, "Viewing Stories", "stories");
 
     // When navigating directly to a story via URL, instagram prompts us
     // whether to click through (because it'll reveal your identity to the
     // original poster)
-    //
-    // No need to do anything else; stories autoplay once you visit them,
-    // including navigation to the next active story from the same account,
-    // so we can just hang out on this page and let every story play through.
     const viewStory = xpathNode(Q.storiesViewStoryButton) as HTMLElement | null;
     if (viewStory) {
       viewStory.click();
     }
+
+    // No need to do anything else; stories autoplay once you visit them,
+    // including navigation to the next active story from the same account,
+    // so we can just hang out on this page and let every story play through.
+    // 60 seconds may not catch all stories but will catch many; we should
+    // probably double check this number.
+    await sleep(60000);
   }
 
   async *run(ctx: Context<InstagramState>) {

--- a/src/site/instagram.ts
+++ b/src/site/instagram.ts
@@ -309,6 +309,11 @@ export class InstagramPostsBehavior
       const storyHalo = xpathNode(Q.storiesHalo) as HTMLElement | null;
       if (storyHalo) {
         const userName = match[1];
+        yield getState(
+          ctx,
+          "Adding link to stories for user " + userName,
+          "stories",
+        );
         await addLink(`https://instagram.com/stories/${userName}/`);
       }
     }

--- a/src/site/instagram.ts
+++ b/src/site/instagram.ts
@@ -19,6 +19,12 @@ const Q = {
   viewReplies: "ul/li//button[span[not(count(*)) and contains(text(), '(')]]",
   loadMore: "//button[span[@aria-label]]",
   pageLoadWaitUntil: "//main",
+  // The clickable ring that appears around a user avatar if the user
+  // has an active story
+  storiesHalo: "//section/div/span/div/div[@role='button']",
+  storiesViewStoryButton:
+    "//section/div[1]/div/div/div/div/div[2]/div/div[3]/div",
+  userPage: /^\/([^/]+)\/?$/,
 };
 
 // These queries match the single-page versions
@@ -37,6 +43,7 @@ type InstagramState = {
   slides: number;
   posts: number;
   rows: number;
+  stories: number;
 };
 
 export class InstagramPostsBehavior
@@ -248,13 +255,50 @@ export class InstagramPostsBehavior
     ]);
   }
 
+  async *handleStories(ctx: Context<InstagramState>) {
+    const { getState, xpathNode } = ctx.Lib;
+
+    yield getState(ctx, "Viewing Stories", "stories");
+
+    // When navigating directly to a story via URL, instagram prompts us
+    // whether to click through (because it'll reveal your identity to the
+    // original poster)
+    //
+    // No need to do anything else; stories autoplay once you visit them,
+    // including navigation to the next active story from the same account,
+    // so we can just hang out on this page and let every story play through.
+    const viewStory = xpathNode(Q.storiesViewStoryButton) as HTMLElement | null;
+    if (viewStory) {
+      viewStory.click();
+    }
+  }
+
   async *run(ctx: Context<InstagramState>) {
     if (window.location.pathname.startsWith("/p/")) {
       yield* this.handleSinglePost(ctx, false);
       return;
     }
 
-    const { getState, scrollIntoView, sleep, waitUnit, xpathNode } = ctx.Lib;
+    if (window.location.pathname.startsWith("/stories/")) {
+      yield* this.handleStories(ctx);
+      return;
+    }
+
+    const { addLink, getState, scrollIntoView, sleep, waitUnit, xpathNode } =
+      ctx.Lib;
+
+    // If we're navigating a profile page, queue up this user's stories
+    const match = Q.userPage.exec(window.location.pathname);
+    if (match) {
+      // This element is only present if the user has stories available to view.
+      // We're not going to click it, just use it as a sign we should be
+      // queuing up the user's stories as a separate URL.
+      const storyHalo = xpathNode(Q.storiesHalo) as HTMLElement | null;
+      if (storyHalo) {
+        const userName = match[1];
+        await addLink(`https://instagram.com/stories/${userName}/`);
+      }
+    }
 
     for await (const row of this.iterRow(ctx)) {
       scrollIntoView(row);


### PR DESCRIPTION
Stories are accessible from a standalone page, but we have to know they're present in order to navigate there.

If we're on a user page, this adds a check to try to detect the presence of the "halo" stories button surrounding the user's avatar. If it's present, then add the stories link to the crawl so we'll visit it later. Luckily, we don't have to *do* anything on stories; we can just sit and let them play out, since they'll auto-advance to the next story after an interval.

I've also added a commit which removes some dead code. The only call to `viewStandalonePost` has been commented out since 269880920b20faa34a77a97b182d61e5fa8bffb9, three years ago, so I've removed both the commented out call and the method itself. We've got other handling for standalone posts at this point.