### PR TITLE
facebook: addLink individual post links

### DIFF
--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -11,6 +11,10 @@ const Q = {
   // In the feed view, comments also have @role='article' but additionally
   // have an @aria-label that actual posts don't have.
   articleList: "//div[@role='article' and not(@aria-label)]",
+  // The above is only true when logged out; when logged in, we need to key
+  // off something else. The aria-posinset attribute is set on posts in the
+  // logged in view.
+  articleListLoggedIn: "//div[@aria-posinset]",
   photosOrVideos: `.//a[(contains(@href, '/photos/') or contains(@href, '/photo/?') or contains(@href, '/videos/')) and (starts-with(@href, '${window.location.origin}/') or starts-with(@href, '/'))]`,
   pagePostRootQuery: "//div[@role='dialog']",
   postQuery: ".//a[contains(@href, '/posts/')]",
@@ -110,6 +114,14 @@ export class FacebookTimelineBehavior
       xpathNode,
       xpathNodes,
     } = ctx.Lib;
+
+    let articleQuery;
+    if (this.isLoggedIn()) {
+      articleQuery = Q.articleListLoggedIn;
+    } else {
+      articleQuery = Q.articleList;
+    }
+
     let feeds = Array.from(xpathNodes(Q.feed)) as Element[];
     if (feeds.length) {
       for (const feed of feeds) {
@@ -122,7 +134,7 @@ export class FacebookTimelineBehavior
         }
       }
     } else if (
-      (feeds = Array.from(xpathNodes(Q.articleList)) as Element[]).length
+      (feeds = Array.from(xpathNodes(articleQuery)) as Element[]).length
     ) {
       for (const post of feeds) {
         yield getState(ctx, "Viewing post from feed");
@@ -135,7 +147,7 @@ export class FacebookTimelineBehavior
       // or hit a limit
       let lastSeen = feeds.at(-1);
       for (let i = 0; i < 50; i++) {
-        feeds = Array.from(xpathNodes(Q.articleList)) as Element[];
+        feeds = Array.from(xpathNodes(articleQuery)) as Element[];
         if (feeds[0] == lastSeen) {
           break;
         }

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -209,7 +209,8 @@ export class FacebookTimelineBehavior
     commentQuery: string,
     maxExpands = 2,
   ) {
-    const { getState, scrollIntoView, sleep, waitUnit, xpathNode } = ctx.Lib;
+    const { addLink, getState, scrollIntoView, sleep, waitUnit, xpathNode } =
+      ctx.Lib;
     if (!post) {
       return;
     }
@@ -224,6 +225,18 @@ export class FacebookTimelineBehavior
     }
 
     yield getState(ctx, "Viewing post " + (url || ""), "posts");
+    // If appropriate, queue up the single post view as well
+    if (url) {
+      const urlString = url.toString();
+      yield getState(ctx, "urlString: " + urlString);
+      if (
+        Q.isSinglePost.test(urlString) ||
+        Q.isSingleGroupPost.test(urlString)
+      ) {
+        yield getState(ctx, "Queuing single page post " + urlString);
+        await addLink(urlString);
+      }
+    }
 
     scrollIntoView(post);
 


### PR DESCRIPTION
If we're browsing a post from the timeline, we should addLink the individual post permalinks so we archive those copies too.

This also contains a fix to timeline scrolling which ensures we iterate over the correct HTML elements when logged in. The HTML structure differed between the logged out and logged in view. This didn't matter much previously, since we ended up scrolling through anyway, but we do need to be more precise if we're going to get post links.