### PR TITLE
Facebook: post-0.10.0 fixes

### DIFF
--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -688,6 +688,11 @@ export class FacebookTimelineBehavior
       loginModal.click();
     }
 
+    if (window.location.pathname == "/") {
+      yield getState(ctx, "Not browsing the home timeline");
+      return;
+    }
+
     if (Q.isPhotosPage.exec(window.location.href)) {
       ctx.state = { photos: 0, comments: 0 };
       yield getState(ctx, "Iterating photos");

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -228,7 +228,6 @@ export class FacebookTimelineBehavior
     // If appropriate, queue up the single post view as well
     if (url) {
       const urlString = url.toString();
-      yield getState(ctx, "urlString: " + urlString);
       if (
         Q.isSinglePost.test(urlString) ||
         Q.isSingleGroupPost.test(urlString)

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -59,12 +59,23 @@ const Q = {
     "following::a[contains(@href, '/videos/') and @aria-hidden!='true']",
   isPhotoVideoPage: /^.*facebook\.com\/[^/]+\/(photos|videos)\/.+/,
   isPhotosPage: /^.*facebook\.com\/[^/]+\/photos\/?($|\?)/,
+  isSinglePhoto: /^.*facebook\.com\/photo.php\/?($|\?)/,
   isVideosPage: /^.*facebook\.com\/[^/]+\/videos\/?($|\?)/,
   isReelsPage: /^.*facebook\.com\/[^/]+\/reels\/?($|\?)/,
+  // This is the list of recommended reels for your account,
+  // *not* the reels posted by a particular page
+  isReelsTab: /^.*facebook\.com\/reelsTab\/?($|\?)/,
+  isSingleReel: /^.*facebook\.com\/reel\/\d+\/?($|\?)/,
   // Post from an organization/etc. page
   isSinglePost: /^.*facebook\.com\/\w+\/posts\/[^/]+\/?($|\?)/,
   // Post from a group
   isSingleGroupPost: /^.*facebook\.com\/groups\/[^/]+\/posts\/[^/]+\/?($|\?)/,
+  isGroupPage: /^.*facebook\.com\/groups\/[^/]+\/?($|\?)/,
+  isOrganizationOrPersonPage: /^.*facebook\.com\/[^/]+/,
+  isMarketplace: /^.*facebook\.com\/marketplace/,
+  isFriends: /^.*facebook\.com\/friends/,
+  isGaming: /^.*facebook\.com\/gaming/,
+  isNotifications: /^.*facebook\.com\/notifications/,
   pageLoadWaitUntil: "//div[@role='main']",
   // Limit query to only modals with the login_popup_cta_form form child in order
   // to avoid grabbing unrelated modals, like pop-up posts
@@ -89,7 +100,27 @@ export class FacebookTimelineBehavior
   static id = "Facebook" as const;
 
   static isMatch() {
-    return !!window.location.href.match(/https:\/\/(www\.)?facebook\.com\//);
+    // Attempts to restrict the behaviour to the classes of pages
+    // we're set up to be able to iterate over.
+    return (
+      // We want anything in these categories
+      (!!window.location.href.match(Q.isPhotoVideoPage) ||
+        !!window.location.href.match(Q.isPhotosPage) ||
+        !!window.location.href.match(Q.isSinglePhoto) ||
+        !!window.location.href.match(Q.isVideosPage) ||
+        !!window.location.href.match(Q.isReelsPage) ||
+        !!window.location.href.match(Q.isSingleReel) ||
+        !!window.location.href.match(Q.isSinglePost) ||
+        !!window.location.href.match(Q.isSingleGroupPost) ||
+        !!window.location.href.match(Q.isGroupPage) ||
+        !!window.location.href.match(Q.isOrganizationOrPersonPage)) &&
+      // And *avoid* anything in these categories
+      !window.location.href.match(Q.isMarketplace) &&
+      !window.location.href.match(Q.isFriends) &&
+      !window.location.href.match(Q.isGaming) &&
+      !window.location.href.match(Q.isNotifications) &&
+      !window.location.href.match(Q.isReelsTab)
+    );
   }
 
   static init() {

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -684,6 +684,7 @@ export class FacebookTimelineBehavior
     // before trying to interact with the page in any other way.
     const loginModal = xpathNode(Q.loginModal) as HTMLElement | null;
     if (loginModal) {
+      yield getState(ctx, "Closing login modal");
       loginModal.click();
     }
 

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -62,9 +62,6 @@ const Q = {
   isSinglePhoto: /^.*facebook\.com\/photo.php\/?($|\?)/,
   isVideosPage: /^.*facebook\.com\/[^/]+\/videos\/?($|\?)/,
   isReelsPage: /^.*facebook\.com\/[^/]+\/reels\/?($|\?)/,
-  // This is the list of recommended reels for your account,
-  // *not* the reels posted by a particular page
-  isReelsTab: /^.*facebook\.com\/reelsTab\/?($|\?)/,
   isSingleReel: /^.*facebook\.com\/reel\/\d+\/?($|\?)/,
   // Post from an organization/etc. page
   isSinglePost: /^.*facebook\.com\/\w+\/posts\/[^/]+\/?($|\?)/,
@@ -72,10 +69,8 @@ const Q = {
   isSingleGroupPost: /^.*facebook\.com\/groups\/[^/]+\/posts\/[^/]+\/?($|\?)/,
   isGroupPage: /^.*facebook\.com\/groups\/[^/]+\/?($|\?)/,
   isOrganizationOrPersonPage: /^.*facebook\.com\/[^/]+/,
-  isMarketplace: /^.*facebook\.com\/marketplace/,
-  isFriends: /^.*facebook\.com\/friends/,
-  isGaming: /^.*facebook\.com\/gaming/,
-  isNotifications: /^.*facebook\.com\/notifications/,
+  isNonHandledPageType:
+    /^.*facebook\.com\/(business|friends|gaming|help|marketplace|notifications|policies|privacy|stories)(\/|\?)/,
   pageLoadWaitUntil: "//div[@role='main']",
   // Limit query to only modals with the login_popup_cta_form form child in order
   // to avoid grabbing unrelated modals, like pop-up posts
@@ -115,11 +110,7 @@ export class FacebookTimelineBehavior
         !!window.location.href.match(Q.isGroupPage) ||
         !!window.location.href.match(Q.isOrganizationOrPersonPage)) &&
       // And *avoid* anything in these categories
-      !window.location.href.match(Q.isMarketplace) &&
-      !window.location.href.match(Q.isFriends) &&
-      !window.location.href.match(Q.isGaming) &&
-      !window.location.href.match(Q.isNotifications) &&
-      !window.location.href.match(Q.isReelsTab)
+      !window.location.href.match(Q.isNonHandledPageType)
     );
   }
 

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -754,6 +754,6 @@ export class FacebookTimelineBehavior
 
     await waitUntilNode(Q.pageLoadWaitUntil, document, null, 10000);
 
-    assertContentValid(() => !this.isLoggedIn(), "not_logged_in");
+    assertContentValid(() => this.isLoggedIn(), "not_logged_in");
   }
 }


### PR DESCRIPTION
This contains several fixes for things discovered after the release of 0.10.0, which mostly affect a logged-in context.

* The `not_logged_in` condition was accidentally negated, breaking the logged-in check.
* We should refuse to crawl the base `facebook.com` timeline. All our timeline browsing has been tested on organization/group/etc pages, and the home timeline very likely contains different structure that's not safe for us to browse.
* Removed a debug log that snuck in by accident and add a log when we close the login modal.
* Adjusted the `isMatch` function so that we much more aggressively pare ourselves back to only the kinds of URLs we think we can work on, which avoids us running on the main facebook.com feed or other pages where we might end up doing the wrong thing.