### PR TITLE
youtube: rework to set media source settings

### DIFF
--- a/src/site/index.ts
+++ b/src/site/index.ts
@@ -4,6 +4,7 @@ import { InstagramPostsBehavior } from "./instagram";
 import { TelegramBehavior } from "./telegram";
 import { TwitterTimelineBehavior } from "./twitter";
 import { TikTokVideoBehavior, TikTokProfileBehavior } from "./tiktok";
+import { YoutubeBehavior } from "./youtube";
 
 const siteBehaviors = [
   BlueskyBehavior,
@@ -13,6 +14,7 @@ const siteBehaviors = [
   TelegramBehavior,
   TikTokVideoBehavior,
   TikTokProfileBehavior,
+  YoutubeBehavior,
 ] as const;
 
 export default siteBehaviors;

--- a/src/site/youtube.ts
+++ b/src/site/youtube.ts
@@ -1,9 +1,71 @@
-import { AutoScroll } from "../autoscroll";
-import { type Context } from "../lib/behavior";
+import { type AbstractBehavior, type Context } from "../lib/behavior";
 
-export class YoutubeBehavior extends AutoScroll {
-  static override id = "Youtube" as const;
-  async awaitPageLoad(ctx: Context<{}, {}>) {
+type YoutubeState = {};
+
+export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
+  static id = "Youtube" as const;
+
+  static init() {
+    return {
+      state: {},
+    };
+  }
+
+  static isMatch() {
+    return !!window.location.href.match(/https:\/\/(www\.)?youtube\.com\//);
+  }
+
+  async *run(ctx: Context<YoutubeState>) {
+    const { getState } = ctx.Lib;
+
+    // Attempt to induce YouTube into serving up older video formats
+    yield getState(ctx, "Setting MediaSourc.isTypeSupported to return false");
+    Object.defineProperty(MediaSource, "isTypeSupported", {
+      value: () => false,
+      configurable: false,
+      writable: false,
+    });
+
+    yield getState(ctx, "Overriding canPlayType to return false for av01");
+    const canPlayType = HTMLMediaElement.prototype.canPlayType;
+    Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value: (type: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        if (/av01/.test(type)) {
+          return "";
+        } else {
+          return canPlayType.call(this, type);
+        }
+      },
+      configurable: false,
+      writable: false,
+    });
+
+    yield getState(
+      ctx,
+      "Overriding MediaCapabilities.decodingInfo() to mark av01 not supported",
+    );
+    const decodingInfo = navigator.mediaCapabilities.decodingInfo;
+    Object.defineProperty(navigator.mediaCapabilities, "decodingInfo", {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value: async (configuration: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        if (
+          configuration.video &&
+          /av01/.test(configuration.video.contentType)
+        ) {
+          return { supported: false, smooth: false, powerEfficient: false };
+        } else {
+          return decodingInfo.call(this, configuration);
+        }
+      },
+      configurable: false,
+      writable: false,
+    });
+  }
+
+  async awaitPageLoad(ctx: Context<YoutubeState>) {
     const { sleep, assertContentValid } = ctx.Lib;
     await sleep(10);
     assertContentValid(() => {


### PR DESCRIPTION
This reworks the Youtube behaviour to introduce its own logic. Previously, this was a subclass of autoscroll which overrode the `awaitPageLoad` method; this new version retains the `awaitPageLoad` logic but adds new logic to try and influence video format autoselection. I took inspiration from several userscripts I've seen around, for example https://github.com/HardMeister/yt-vp9-codec-enforcer

This is not fully tested: I've confirmed it *runs*, but we need to confirm that the video format that was selected is what we'd like to see, and we need replay-side changes and testing to confirm everything.