### PR TITLE
YouTube: add media behaviour to onPageInit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-behaviors",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "main": "index.js",
   "author": "Webrecorder Software",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,14 @@ export class BehaviorManager {
         const siteBehaviorClass = this.loadedBehaviors[name];
         if ("isMatch" in siteBehaviorClass && siteBehaviorClass.isMatch()) {
           void behaviorLog("Using Site-Specific Behavior: " + name);
+
+          if ("onPageInit" in siteBehaviorClass) {
+            void behaviorLog(
+              "Calling onPageInit for Site-Specific Behavior " + name,
+            );
+            siteBehaviorClass.onPageInit();
+          }
+
           this.mainBehaviorClass = siteBehaviorClass;
           const siteSpecificOpts =
             typeof opts.siteSpecific === "object"
@@ -200,10 +208,6 @@ export class BehaviorManager {
             );
           }
           siteMatch = true;
-
-          if ("onPageInit" in this.mainBehaviorClass) {
-            this.mainBehaviorClass.onPageInit();
-          }
 
           break;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,11 @@ export class BehaviorManager {
             );
           }
           siteMatch = true;
+
+          if ("onPageInit" in this.mainBehaviorClass) {
+            this.mainBehaviorClass.onPageInit();
+          }
+
           break;
         }
       }

--- a/src/site/youtube.ts
+++ b/src/site/youtube.ts
@@ -22,39 +22,6 @@ export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
       configurable: false,
       writable: false,
     });
-
-    const canPlayType = HTMLMediaElement.prototype.canPlayType;
-    Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      value: (type: any) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        if (/av01/.test(type)) {
-          return "";
-        } else {
-          return canPlayType.call(this, type);
-        }
-      },
-      configurable: false,
-      writable: false,
-    });
-
-    const decodingInfo = navigator.mediaCapabilities.decodingInfo;
-    Object.defineProperty(navigator.mediaCapabilities, "decodingInfo", {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      value: async (configuration: any) => {
-        if (
-          configuration.video &&
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          /av01/.test(configuration.video.contentType)
-        ) {
-          return { supported: false, smooth: false, powerEfficient: false };
-        } else {
-          return decodingInfo.call(this, configuration);
-        }
-      },
-      configurable: false,
-      writable: false,
-    });
   }
 
   async *run(_ctx: Context<YoutubeState>) {}

--- a/src/site/youtube.ts
+++ b/src/site/youtube.ts
@@ -12,7 +12,9 @@ export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
   }
 
   static isMatch() {
-    return !!window.location.href.match(/^https:\/\/(www\.)?youtube(-nocookie)?\.com\//);
+    return !!window.location.href.match(
+      /^https:\/\/(www\.)?youtube(-nocookie)?\.com\//,
+    );
   }
 
   static onPageInit() {

--- a/src/site/youtube.ts
+++ b/src/site/youtube.ts
@@ -1,9 +1,71 @@
-import { AutoScroll } from "../autoscroll";
-import { type Context } from "../lib/behavior";
+import { type AbstractBehavior, type Context } from "../lib/behavior";
 
-export class YoutubeBehavior extends AutoScroll {
-  static override id = "Youtube" as const;
-  async awaitPageLoad(ctx: Context<{}, {}>) {
+type YoutubeState = {};
+
+export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
+  static id = "Youtube" as const;
+
+  static init() {
+    return {
+      state: {},
+    };
+  }
+
+  static isMatch() {
+    return !!window.location.href.match(/https:\/\/(www\.)?youtube\.com\//);
+  }
+
+  async *run(ctx: Context<YoutubeState>) {
+    const { getState } = ctx.Lib;
+
+    // Attempt to induce YouTube into serving up older video formats
+    yield getState(ctx, "Setting MediaSourc.isTypeSupported to return false");
+    Object.defineProperty(MediaSource, "isTypeSupported", {
+      value: () => false,
+      configurable: false,
+      writable: false,
+    });
+
+    yield getState(ctx, "Overriding canPlayType to return false for av01");
+    const canPlayType = HTMLMediaElement.prototype.canPlayType;
+    Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value: (type: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        if (/av01/.test(type)) {
+          return "";
+        } else {
+          return canPlayType.call(this, type);
+        }
+      },
+      configurable: false,
+      writable: false,
+    });
+
+    yield getState(
+      ctx,
+      "Overriding MediaCapabilities.decodingInfo() to mark av01 not supported",
+    );
+    const decodingInfo = navigator.mediaCapabilities.decodingInfo;
+    Object.defineProperty(navigator.mediaCapabilities, "decodingInfo", {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value: async (configuration: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        if (
+          configuration.video &&
+          /av01/.test(configuration.video.contentType)
+        ) {
+          return { supported: false, smooth: false, powerEfficient: false };
+        } else {
+          return decodingInfo.call(this, configuration);
+        }
+      },
+      configurable: false,
+      writable: false,
+    });
+  }
+
+  async awaitPageLoad(ctx: Context<YoutubeState>) {
     const { sleep, assertContentValid } = ctx.Lib;
     await sleep(10);
     assertContentValid(() => {

--- a/src/site/youtube.ts
+++ b/src/site/youtube.ts
@@ -17,17 +17,8 @@ export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
 
   static onPageInit() {
     // Attempt to induce YouTube into serving up older video formats
-    const isTypeSupported = MediaSource.isTypeSupported.bind(MediaSource);
     Object.defineProperty(MediaSource, "isTypeSupported", {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      value: (type: any) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        if (/av01/.test(type)) {
-          return false;
-        } else {
-          return isTypeSupported.call(MediaSource, type);
-        }
-      },
+      value: () => false,
       configurable: false,
       writable: false,
     });

--- a/src/site/youtube.ts
+++ b/src/site/youtube.ts
@@ -12,7 +12,7 @@ export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
   }
 
   static isMatch() {
-    return !!window.location.href.match(/https:\/\/(www\.)?youtube\.com\//);
+    return !!window.location.href.match(/^https:\/\/(www\.)?youtube(-nocookie)?\.com\//);
   }
 
   static onPageInit() {

--- a/src/site/youtube.ts
+++ b/src/site/youtube.ts
@@ -15,18 +15,23 @@ export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
     return !!window.location.href.match(/https:\/\/(www\.)?youtube\.com\//);
   }
 
-  async *run(ctx: Context<YoutubeState>) {
-    const { getState } = ctx.Lib;
-
+  static onPageInit() {
     // Attempt to induce YouTube into serving up older video formats
-    yield getState(ctx, "Setting MediaSourc.isTypeSupported to return false");
+    const isTypeSupported = MediaSource.isTypeSupported.bind(MediaSource);
     Object.defineProperty(MediaSource, "isTypeSupported", {
-      value: () => false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value: (type: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        if (/av01/.test(type)) {
+          return false;
+        } else {
+          return isTypeSupported.call(MediaSource, type);
+        }
+      },
       configurable: false,
       writable: false,
     });
 
-    yield getState(ctx, "Overriding canPlayType to return false for av01");
     const canPlayType = HTMLMediaElement.prototype.canPlayType;
     Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,17 +47,13 @@ export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
       writable: false,
     });
 
-    yield getState(
-      ctx,
-      "Overriding MediaCapabilities.decodingInfo() to mark av01 not supported",
-    );
     const decodingInfo = navigator.mediaCapabilities.decodingInfo;
     Object.defineProperty(navigator.mediaCapabilities, "decodingInfo", {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       value: async (configuration: any) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         if (
           configuration.video &&
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           /av01/.test(configuration.video.contentType)
         ) {
           return { supported: false, smooth: false, powerEfficient: false };
@@ -64,6 +65,8 @@ export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
       writable: false,
     });
   }
+
+  async *run(_ctx: Context<YoutubeState>) {}
 
   async awaitPageLoad(ctx: Context<YoutubeState>) {
     const { sleep, assertContentValid } = ctx.Lib;


### PR DESCRIPTION
This is equivalent logic to what we were looking to add in wabac.js - https://github.com/webrecorder/wabac.js/pull/343 / https://github.com/webrecorder/wabac.js/pull/348.

We couldn't do this at `run()` time because it's too late, but this may be early enough to work.