### PR TITLE
YouTube: wait for video to play

### DIFF
--- a/src/site/youtube.ts
+++ b/src/site/youtube.ts
@@ -26,7 +26,15 @@ export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
     });
   }
 
-  async *run(_ctx: Context<YoutubeState>) {}
+  async *run(ctx: Context<YoutubeState>) {
+    const { getState, sleep, waitUnit } = ctx.Lib;
+
+    const video = document.querySelector("video");
+    if (video) {
+      yield getState(ctx, "Waiting for video to play");
+      await sleep(waitUnit * 60);
+    }
+  }
 
   async awaitPageLoad(ctx: Context<YoutubeState>) {
     const { sleep, assertContentValid } = ctx.Lib;


### PR DESCRIPTION
Hypothetically, the crawler should be waiting for the request to finish, but in the meantime this fixes certain videos that get cut off for now.