### PR TITLE
addLink() needs an option to alwaysObeyScope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-behaviors",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "main": "index.js",
   "author": "Webrecorder Software",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -433,6 +433,8 @@ export class BehaviorManager {
     const promises: Promise<void>[] = [];
 
     for (const url of urls) {
+      // add link for each matched URL, but only if in scope
+      // this is called from main link extraction in the crawler
       // pass true to always follow scope, even if allowed to ignore
       promises.push(addLink(url, true));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -433,7 +433,8 @@ export class BehaviorManager {
     const promises: Promise<void>[] = [];
 
     for (const url of urls) {
-      promises.push(addLink(url));
+      // pass true to always follow scope, even if allowed to ignore
+      promises.push(addLink(url, true));
     }
 
     await Promise.allSettled(promises);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -145,7 +145,10 @@ export async function behaviorLog(data: LogData, type = "debug") {
   }
 }
 
-export async function addLink(url: string, alwaysObeyScope = false): Promise<void> {
+export async function addLink(
+  url: string,
+  alwaysObeyScope = false,
+): Promise<void> {
   if (typeof self["__bx_addLink"] === "function") {
     // call directly as passing two objects
     return await self["__bx_addLink"](url, alwaysObeyScope);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -145,9 +145,10 @@ export async function behaviorLog(data: LogData, type = "debug") {
   }
 }
 
-export async function addLink(url: string): Promise<void> {
+export async function addLink(url: string, alwaysObeyScope = false): Promise<void> {
   if (typeof self["__bx_addLink"] === "function") {
-    return await callBinding(self["__bx_addLink"], url);
+    // call directly as passing two objects
+    return await self["__bx_addLink"](url, alwaysObeyScope);
   }
 }
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,7 +1,7 @@
 import { type BehaviorManager } from "../src";
 
 interface BehaviorGlobals {
-  __bx_addLink?: (url: string) => Promise<void>;
+  __bx_addLink?: (url: string, alwaysObeyScope: boolean) => Promise<void>;
   __bx_fetch?: (url: string) => Promise<boolean>;
   __bx_addSet?: (url: string) => Promise<boolean>;
   __bx_netIdle?: (params: {


### PR DESCRIPTION
To ensure regular link extraction works as expected, even if allowed to ignore scope.
Regular link extraction calls `addLink(url, true);`
Call binding directly with two params.

Alternative: could also add a `addLinkIfInScope(url)` helper if that would be clearer