### PR TITLE
facebook: call addLink() for individual reel pages as well

### DIFF
--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -668,6 +668,10 @@ export class FacebookTimelineBehavior
       xpathNode(Q.nextReelCardAlt)) as HTMLElement | null;
 
     while (nextButton) {
+      if (!window.location.href.startsWith("https://www.facebook.com/reel/")) {
+        break;
+      }
+
       yield getState(ctx, "Viewing reel: " + window.location.href, "reels");
       await addLink(window.location.href);
 

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -646,6 +646,7 @@ export class FacebookTimelineBehavior
       waitUntil,
       xpathNode,
       xpathNodes,
+      addLink,
     } = ctx.Lib;
 
     const videoLink = (xpathNode(Q.firstReelThumbnail) ||
@@ -668,6 +669,8 @@ export class FacebookTimelineBehavior
 
     while (nextButton) {
       yield getState(ctx, "Viewing reel: " + window.location.href, "reels");
+      await addLink(window.location.href);
+
       // wait for video to play, or 20s
       await Promise.race([
         waitUntil(() => {


### PR DESCRIPTION
Just like posts, we should call addLink() on individual reel pages as they have a unique URL as well.