### PR TITLE
facebook: tighten username regex

### DIFF
--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -68,9 +68,10 @@ const Q = {
   // Post from a group
   isSingleGroupPost: /^.*facebook\.com\/groups\/[^/]+\/posts\/[^/]+\/?($|\?)/,
   isGroupPage: /^.*facebook\.com\/groups\/[^/]+\/?($|\?)/,
+  isGroupFeed: /^.*facebook\.com\/groups\/feed\/?($|\?)/,
   isOrganizationOrPersonPage: /^.*facebook\.com\/([a-zA-Z0-9.]+)/,
   isNonHandledPageType:
-    /^.*facebook\.com\/(business|friends|gaming|help|marketplace|notifications|policies|privacy|stories)(\/|\?)/,
+    /^.*facebook\.com\/(business|friends|gaming|help|marketplace|notifications|policies|privacy|stories|groups\/feed|login\.php)(\/|\?)/,
   pageLoadWaitUntil: "//div[@role='main']",
   // Limit query to only modals with the login_popup_cta_form form child in order
   // to avoid grabbing unrelated modals, like pop-up posts
@@ -727,6 +728,11 @@ export class FacebookTimelineBehavior
 
     if (window.location.pathname == "/") {
       yield getState(ctx, "Not browsing the home timeline");
+      return;
+    }
+
+    if (Q.isGroupFeed.exec(window.location.href)) {
+      yield getState(ctx, "Not browsing the group feed");
       return;
     }
 

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -68,7 +68,7 @@ const Q = {
   // Post from a group
   isSingleGroupPost: /^.*facebook\.com\/groups\/[^/]+\/posts\/[^/]+\/?($|\?)/,
   isGroupPage: /^.*facebook\.com\/groups\/[^/]+\/?($|\?)/,
-  isOrganizationOrPersonPage: /^.*facebook\.com\/([^/]+)/,
+  isOrganizationOrPersonPage: /^.*facebook\.com\/([a-zA-Z0-9.]+)/,
   isNonHandledPageType:
     /^.*facebook\.com\/(business|friends|gaming|help|marketplace|notifications|policies|privacy|stories)(\/|\?)/,
   pageLoadWaitUntil: "//div[@role='main']",


### PR DESCRIPTION
We noticed that this was catching a wider variety of pages than we intended; we should restrict the username section of this regex down to only the characters that can appear in a username.

This is less of an issue with the other regular expressions because they have sections that follow the username that make them more specific, but this is the only thing we match in this one.

From Facebook: https://www.facebook.com/help/web/105399436216001/

> Usernames can only contain alphanumeric characters (A–Z, 0–9) and periods (".").