### PR TITLE
facebook: avoid running on instagram/login_sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-behaviors",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "main": "index.js",
   "author": "Webrecorder Software",
   "repository": {

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -71,7 +71,7 @@ const Q = {
   isGroupFeed: /^.*facebook\.com\/groups\/feed\/?($|\?)/,
   isOrganizationOrPersonPage: /^.*facebook\.com\/([a-zA-Z0-9.]+)/,
   isNonHandledPageType:
-    /^.*facebook\.com\/(business|friends|gaming|help|marketplace|notifications|policies|privacy|stories|groups\/feed|login\.php)(\/|\?)/,
+    /^.*facebook\.com\/(business|friends|gaming|help|marketplace|notifications|policies|privacy|stories|groups\/feed|login\.php|instagram\/login_sync)(\/|\?)/,
   pageLoadWaitUntil: "//div[@role='main']",
   // Limit query to only modals with the login_popup_cta_form form child in order
   // to avoid grabbing unrelated modals, like pop-up posts


### PR DESCRIPTION
Instagram has an iframe for `facebook.com/instagram/login_sync` on many pages. This was triggering the Facebook behaviour, which then went on to `addLink` new pages at the `facebook.com/instagram` root. We need to make sure that we don't run our Facebook behaviours, at all, on this URL.

This was causing an Instagram crawl to do a few things we didn't want:

* Add `www.facebook.com/instagram/photos` and `www.facebook.com/instagram/reels` to the list of URLs to crawl
* Error out with `not_logged_in` at this iframe and the two above URLs because