### PR TITLE
facebook: avoid `addLink`ing to `reel`

### DIFF
--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -789,7 +789,7 @@ export class FacebookTimelineBehavior
     const match = window.location.href.match(Q.isOrganizationOrPersonPage);
     if (match) {
       const account = match[1];
-      if (account && account != "groups") {
+      if (account && account != "groups" && account != "reel") {
         const photosPage = `https://www.facebook.com/${account}/photos`;
         yield getState(ctx, `Adding link to photos page: ${photosPage}`);
         await addLink(photosPage);


### PR DESCRIPTION
We can reach this function if we got here via a single reel. We ended up mistaking `facebook.com/reel/$REEL_ID` for a post on the userpage `reel` and therefore `addLink`ing `reel/reels` and `reel/photos`. This is a 404 page so it didn't hurt much and we would capture it quickly, but it's best if we avoid capturing it at all.