### PR TITLE
facebook: wait more aggressively for reels

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,6 +24,13 @@ export async function scrollAndClick(
 
 export const waitUnit = 200;
 
+// Returns a random number between 150 and 250.
+// Useful for performing a wait with a less predictable timer than
+// using the fixed waitUnit.
+export function fuzzyWaitUnit(): number {
+  return Math.floor(Math.random() * (250 - 150) + 150);
+}
+
 export async function sleep(timeout: number) {
   return new Promise((resolve) => setTimeout(resolve, timeout));
 }

--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -641,6 +641,7 @@ export class FacebookTimelineBehavior
   async *iterAllReels(ctx: Context<FacebookState>) {
     const {
       addLink,
+      fuzzyWaitUnit,
       getState,
       scrollIntoView,
       sleep,
@@ -663,7 +664,7 @@ export class FacebookTimelineBehavior
     videoLink.click();
     await waitUntil(() => window.location.href !== lastHref, waitUnit * 2);
 
-    await sleep(waitUnit * 10);
+    await sleep(fuzzyWaitUnit() * 10);
 
     let nextButton = (xpathNode(Q.nextReelCard) ||
       xpathNode(Q.nextReelCardAlt)) as HTMLElement | null;
@@ -684,7 +685,7 @@ export class FacebookTimelineBehavior
         await addLink(window.location.href);
       }
 
-      // wait for video to play, or 20s
+      // wait for video to play, or ~20s
       await Promise.race([
         waitUntil(() => {
           for (const video of xpathNodes(
@@ -695,11 +696,12 @@ export class FacebookTimelineBehavior
             }
           }
           return false;
-        }, waitUnit * 2),
-        sleep(20000),
+        }, fuzzyWaitUnit() * 2),
+        sleep(fuzzyWaitUnit() * 100),
       ]);
 
-      await sleep(waitUnit * 10);
+      // Continue waiting for the video to finish playing out
+      await sleep(fuzzyWaitUnit() * 100);
 
       nextButton = (xpathNode(Q.nextReelCard) ||
         xpathNode(Q.nextReelCardAlt)) as HTMLElement | null;
@@ -707,7 +709,10 @@ export class FacebookTimelineBehavior
       if (nextButton) {
         nextButton.click();
         lastHref = window.location.href;
-        await waitUntil(() => window.location.href !== lastHref, waitUnit * 2);
+        await waitUntil(
+          () => window.location.href !== lastHref,
+          fuzzyWaitUnit() * 5,
+        );
       }
     }
   }


### PR DESCRIPTION
This increases the play wait time for reels. It also introduces a new fuzzy wait function; rather than using a fixed wait unit of 200ms, it picks a random number between 150 and 250 in order to let us use a fuzzier set of wait times while still being approximately in line with the original value.