### PR TITLE
use addLinkBatch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
   _setLogFunc,
   _setBehaviorManager,
   installBehaviors,
-  addLink,
+  addLinkBatch,
   checkToJsonOverride,
 } from "./lib/utils";
 import { type AbstractBehavior, BehaviorRunner } from "./lib/behavior";
@@ -431,13 +431,10 @@ export class BehaviorManager {
     });
 
     const promises: Promise<void>[] = [];
-
-    for (const url of urls) {
-      // add link for each matched URL, but only if in scope
-      // this is called from main link extraction in the crawler
-      // pass true to always follow scope, even if allowed to ignore
-      promises.push(addLink(url, true));
-    }
+    // add link for each matched URL, but only if in scope
+    // this is called from main link extraction in the crawler
+    // pass true to always follow scope, even if allowed to ignore
+    promises.push(addLinkBatch(urls, true));
 
     await Promise.allSettled(promises);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -434,10 +434,7 @@ export class BehaviorManager {
     // add link for each matched URL, but only if in scope
     // this is called from main link extraction in the crawler
     // pass true to always follow scope, even if allowed to ignore
-    // We join them into a string here to send back more quickly over
-    // the debug protocol, and they'll be split back out again
-    // in the crawler.
-    promises.push(addLinkBatch(Array.from(urls).join("\n\n"), true));
+    promises.push(addLinkBatch(Array.from(urls), true));
 
     await Promise.allSettled(promises);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -434,7 +434,10 @@ export class BehaviorManager {
     // add link for each matched URL, but only if in scope
     // this is called from main link extraction in the crawler
     // pass true to always follow scope, even if allowed to ignore
-    promises.push(addLinkBatch(urls, true));
+    // We join them into a string here to send back more quickly over
+    // the debug protocol, and they'll be split back out again
+    // in the crawler.
+    promises.push(addLinkBatch(Array.from(urls).join("\n\n"), true));
 
     await Promise.allSettled(promises);
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -163,12 +163,22 @@ export async function addLink(
 }
 
 export async function addLinkBatch(
-  urls: string,
+  urls: string[],
   alwaysObeyScope = false,
 ): Promise<void> {
   if (typeof self["__bx_addLinkBatch"] === "function") {
-    // call directly as passing two objects
-    return await self["__bx_addLinkBatch"](urls, alwaysObeyScope);
+    const promises = [];
+    // Pipe through at most 2500 URLs at a time
+    for (let i = 0; i < Math.ceil(urls.length / 2500); i++) {
+      const slice = urls.slice(2500 * i, 2500 * (i + 1));
+      // We join them into a string here to send back more quickly over
+      // the debug protocol, and they'll be split back out again
+      // in the crawler.
+      promises.push(
+        self["__bx_addLinkBatch"](slice.join("\n\n"), alwaysObeyScope),
+      );
+    }
+    await Promise.all(promises);
   }
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -167,10 +167,24 @@ export async function addLinkBatch(
   alwaysObeyScope = false,
 ): Promise<void> {
   if (typeof self["__bx_addLinkBatch"] === "function") {
+    // Slice up the array into subarrays of up to 1MB worth of URLs
+    const slices: string[][] = [[]];
+    let currentSlice = 0;
+    let currentLength = 0;
+
+    for (const url of urls) {
+      if (currentLength >= 1048576) {
+        slices.push([]);
+        currentSlice += 1;
+        currentLength = 0;
+      }
+
+      slices[currentSlice].push(url);
+      currentLength += url.length + 2;
+    }
+
     const promises = [];
-    // Pipe through at most 2500 URLs at a time
-    for (let i = 0; i < Math.ceil(urls.length / 2500); i++) {
-      const slice = urls.slice(2500 * i, 2500 * (i + 1));
+    for (const slice of slices) {
       // We join them into a string here to send back more quickly over
       // the debug protocol, and they'll be split back out again
       // in the crawler.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -163,7 +163,7 @@ export async function addLink(
 }
 
 export async function addLinkBatch(
-  urls: Set<string>,
+  urls: string,
   alwaysObeyScope = false,
 ): Promise<void> {
   if (typeof self["__bx_addLinkBatch"] === "function") {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,6 +6,8 @@ export type LogData = string | { msg: string; [k: string]: unknown };
 let _logFunc: ((...data: unknown[]) => void) | null = console.log;
 let _behaviorMgrClass: typeof BehaviorManager | null = null;
 
+const ONE_MEGABYTE = 1048576;
+
 const scrollOpts: ScrollIntoViewOptions = {
   behavior: "smooth",
   block: "center",
@@ -168,30 +170,27 @@ export async function addLinkBatch(
 ): Promise<void> {
   if (typeof self["__bx_addLinkBatch"] === "function") {
     // Slice up the array into subarrays of up to 1MB worth of URLs
-    const slices: string[][] = [[]];
-    let currentSlice = 0;
+    let slice: string[] = [];
     let currentLength = 0;
+    const promises = [];
 
     for (const url of urls) {
-      if (currentLength >= 1048576) {
-        slices.push([]);
-        currentSlice += 1;
+      if (currentLength >= ONE_MEGABYTE) {
+        // We join them into a string here to send back more quickly over
+        // the debug protocol, and they'll be split back out again
+        // in the crawler.
+        promises.push(
+          self["__bx_addLinkBatch"](slice.join("\n\n"), alwaysObeyScope),
+        );
+
+        slice = [];
         currentLength = 0;
       }
 
-      slices[currentSlice].push(url);
+      slice.push(url);
       currentLength += url.length + 2;
     }
 
-    const promises = [];
-    for (const slice of slices) {
-      // We join them into a string here to send back more quickly over
-      // the debug protocol, and they'll be split back out again
-      // in the crawler.
-      promises.push(
-        self["__bx_addLinkBatch"](slice.join("\n\n"), alwaysObeyScope),
-      );
-    }
     await Promise.all(promises);
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -162,6 +162,16 @@ export async function addLink(
   }
 }
 
+export async function addLinkBatch(
+  urls: Set<string>,
+  alwaysObeyScope = false,
+): Promise<void> {
+  if (typeof self["__bx_addLinkBatch"] === "function") {
+    // call directly as passing two objects
+    return await self["__bx_addLinkBatch"](urls, alwaysObeyScope);
+  }
+}
+
 export async function doExternalFetch(url: string): Promise<boolean> {
   if (typeof self["__bx_fetch"] === "function") {
     return await callBinding(self["__bx_fetch"], url);

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -2,10 +2,7 @@ import { type BehaviorManager } from "../src";
 
 interface BehaviorGlobals {
   __bx_addLink?: (url: string, alwaysObeyScope: boolean) => Promise<void>;
-  __bx_addLinkBatch?: (
-    url: Set<string>,
-    alwaysObeyScope: boolean,
-  ) => Promise<void>;
+  __bx_addLinkBatch?: (urls: string, alwaysObeyScope: boolean) => Promise<void>;
   __bx_fetch?: (url: string) => Promise<boolean>;
   __bx_addSet?: (url: string) => Promise<boolean>;
   __bx_netIdle?: (params: {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -2,6 +2,10 @@ import { type BehaviorManager } from "../src";
 
 interface BehaviorGlobals {
   __bx_addLink?: (url: string, alwaysObeyScope: boolean) => Promise<void>;
+  __bx_addLinkBatch?: (
+    url: Set<string>,
+    alwaysObeyScope: boolean,
+  ) => Promise<void>;
   __bx_fetch?: (url: string) => Promise<boolean>;
   __bx_addSet?: (url: string) => Promise<boolean>;
   __bx_netIdle?: (params: {


### PR DESCRIPTION
Adds the new addLinkBatch helper introduced in
webrecorder/browsertrix-crawler#1137, and uses that to add extracted links in a single action instead of adding each link individually.

refs webrecorder/browsertrix-crawler#160.