### PR TITLE
autoclick: addLink before navigating back

### DIFF
--- a/src/autoclick.ts
+++ b/src/autoclick.ts
@@ -1,5 +1,5 @@
 import { BackgroundBehavior } from "./lib/behavior";
-import { addToExternalSet, sleep } from "./lib/utils";
+import { addLink, addToExternalSet, sleep } from "./lib/utils";
 
 export class AutoClick extends BackgroundBehavior {
   _donePromise: Promise<void>;
@@ -107,6 +107,8 @@ export class AutoClick extends BackgroundBehavior {
       self.history.length === origHistoryLen + 1 &&
       self.location.href != origHref
     ) {
+      // We want to ensure we respect scope here
+      await addLink(self.location.href, true);
       await new Promise((resolve) => {
         window.addEventListener(
           "popstate",


### PR DESCRIPTION
If we've navigated to a new location, make sure we've marked this as a URL to revisit before we navigate back.