### PR TITLE
youtube: wait until <video> element loaded

### DIFF
--- a/src/site/youtube.ts
+++ b/src/site/youtube.ts
@@ -29,8 +29,10 @@ export class YoutubeBehavior implements AbstractBehavior<YoutubeState> {
   async *run(_ctx: Context<YoutubeState>) {}
 
   async awaitPageLoad(ctx: Context<YoutubeState>) {
-    const { sleep, assertContentValid } = ctx.Lib;
-    await sleep(10);
+    const { assertContentValid, waitUntilNode, waitUnit } = ctx.Lib;
+
+    await waitUntilNode("//video", document, null, 10 * waitUnit * 5);
+
     assertContentValid(() => {
       const video = document.querySelector("video");
       const paused = video?.paused;


### PR DESCRIPTION
Our current delay wasn't enough to ensure the video was actually available. It would end up working anyway much of the time because of other things we do that causes us to wait on startup, but if we ever make changes to how we load pages we'll end up losing YouTube video capture unless we become more explicit about waiting for the video.