### PR TITLE
instagram: fix loading slow pages

### DIFF
--- a/src/site/instagram.ts
+++ b/src/site/instagram.ts
@@ -18,7 +18,6 @@ const Q = {
     "//article[@role='presentation']/div[1]/div[2]//ul/div[last()]/div/div",
   viewReplies: "ul/li//button[span[not(count(*)) and contains(text(), '(')]]",
   loadMore: "//button[span[@aria-label]]",
-  pageLoadWaitUntil: "//main",
   // The clickable ring that appears around a user avatar if the user
   // has an active story
   storiesHalo: "//section/div/span/div/div[@role='button']",
@@ -371,7 +370,15 @@ export class InstagramPostsBehavior
 
     void log("Waiting for Instagram to fully load");
 
-    await waitUntilNode(Q.pageLoadWaitUntil, document, null, 10000);
+    // Yes, this is a long wait. Yes, it's necessary. Some very large,
+    // complex pages can genuinely take this long to finish making their
+    // photo grid available.
+    // Important note: just because the main node at //main is available,
+    // this does not mean the photos are! The rest of the page can finish
+    // loading significantly in advance of when the photos are there, and
+    // if we treat it as finished at that point we'll give up on iterating
+    // before the photos become available.
+    await waitUntilNode(Q.rootPath, document, null, 18000);
 
     // It's currently difficult to determine login state on stories,
     // so we skip this check there.

--- a/src/site/instagram.ts
+++ b/src/site/instagram.ts
@@ -370,6 +370,17 @@ export class InstagramPostsBehavior
 
     void log("Waiting for Instagram to fully load");
 
+    // The //main node doesn't exist for stories, so we shouldn't wait
+    // around for it to load on them.
+    // It doesn't seem to be necessary for us to wait any significant
+    // amount of time for the stories to finish loading, unlike
+    // profiles.
+    // It's also currently difficult to determine login state on stories,
+    // so we don't do that check for them.
+    if (window.location.pathname.startsWith("/stories")) {
+      return;
+    }
+
     // Yes, this is a long wait. Yes, it's necessary. Some very large,
     // complex pages can genuinely take this long to finish making their
     // photo grid available.
@@ -380,13 +391,9 @@ export class InstagramPostsBehavior
     // before the photos become available.
     await waitUntilNode(Q.rootPath, document, null, 18000);
 
-    // It's currently difficult to determine login state on stories,
-    // so we skip this check there.
-    if (!window.location.pathname.startsWith("/stories")) {
-      assertContentValid(
-        () => !!document.querySelector("*[aria-label='New post']"),
-        "not_logged_in",
-      );
-    }
+    assertContentValid(
+      () => !!document.querySelector("*[aria-label='New post']"),
+      "not_logged_in",
+    );
   }
 }


### PR DESCRIPTION
Some profiles with very large numbers of photos may take a long period to finish loading. Our previous approach had two problems:

* We were waiting for the `//main` node to load and assumed the page was loaded if that was present. That node is present if the rest of the page has loaded, but the photos can still be missing at this point. Swapping to the `rootPath` query that we use to find photos ensures that this resolves correctly in this case.
* Even the base 10-second wait can be too slow in some extreme cases; pushing this out to 18 seconds allows us to correctly crawl some pages that may just take an excessive amount of time to finish loading.