### PR TITLE
facebook: don't scroll up

### DIFF
--- a/src/site/facebook.ts
+++ b/src/site/facebook.ts
@@ -149,6 +149,14 @@ export class FacebookTimelineBehavior
     if (feeds.length) {
       for (const feed of feeds) {
         for await (const post of iterChildElem(feed, waitUnit, waitUnit * 10)) {
+          if (post.getBoundingClientRect().y < 0) {
+            yield getState(
+              ctx,
+              "Post is above viewport; iterating over posts complete",
+            );
+            return;
+          }
+
           yield* this.viewPost(
             ctx,
             xpathNode(Q.article, post) as Element | null,
@@ -160,6 +168,14 @@ export class FacebookTimelineBehavior
       (feeds = Array.from(xpathNodes(articleQuery)) as Element[]).length
     ) {
       for (const post of feeds) {
+        if (post.getBoundingClientRect().y < 0) {
+          yield getState(
+            ctx,
+            "Post is above viewport; iterating over posts complete",
+          );
+          return;
+        }
+
         yield getState(ctx, "Viewing post from feed");
         scrollIntoView(post);
         yield* this.viewPost(ctx, post, Q.commentList);
@@ -176,6 +192,14 @@ export class FacebookTimelineBehavior
         }
 
         for (const post of feeds) {
+          if (post.getBoundingClientRect().y < 0) {
+            yield getState(
+              ctx,
+              "Post is above viewport; iterating over posts complete",
+            );
+            return;
+          }
+
           yield getState(ctx, "Viewing post from feed");
           scrollIntoView(post);
           yield* this.viewPost(ctx, post, Q.commentList);


### PR DESCRIPTION
We've sometimes seen that, when we reach the end of a feed, we end up scrolling back up to try and find more posts. We should assume that if we ever find a post that's *above* our current Y position, then we've hit the end of the feed and should simply stop.

This is an alternative to #162.

Fixes #164.