### PR TITLE
twitter: add smart scoping rules

### DIFF
--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -313,7 +313,16 @@ export class TwitterTimelineBehavior
     if (this.urlIsTweet() && this.username == this.currentUrlUsername()) {
       const statusId = this.statusIdForUrl();
 
-      const query = `//article[@data-tweet-id='${statusId}']`;
+      let query;
+      if (this.isLoggedIn()) {
+        // Tweets are <article> elements, and the first <article> on
+        // the page should be the primary tweet for the page.
+        query = "//article";
+      } else {
+        // When logged out, the data-tweet-id parameter is set so that
+        // we can be even more confident we're getting the right tweet.
+        query = `//article[@data-tweet-id='${statusId}']`;
+      }
       const tweet = xpathNode(query);
 
       if (tweet) {
@@ -322,7 +331,8 @@ export class TwitterTimelineBehavior
           tweet,
         ) as Generator<HTMLAnchorElement>) {
           // Don't follow internal links, only external ones
-          // NOTE: these don't seem to be t.co anymore??
+          // When logged out, these links go directly to the linked sites;
+          // when logged in, these will be t.co links.
           if (!link.href.match(/https?:\/\/x.com/)) {
             yield getState(ctx, "Following external link: " + link.href);
             await addLink(link.href);

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -403,7 +403,7 @@ export class TwitterTimelineBehavior
   }
 
   currentUrlUsername() {
-    if (this.urlIsProfilePage()) {
+    if (window.location.pathname.match(/^\/[a-zA-Z0-9_]+/)) {
       return window.location.pathname.split("/")[1];
     }
   }

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -269,7 +269,7 @@ export class TwitterTimelineBehavior
     tweet: HTMLElement,
     depth: number,
   ): AsyncGenerator<{ state: TwitterState; msg: string }> {
-    const { getState, HistoryState, sleep, waitUnit } = ctx.Lib;
+    const { addLink, getState, HistoryState, sleep, waitUnit } = ctx.Lib;
     const tweetState = new HistoryState(() => tweet.click());
 
     await sleep(waitUnit);
@@ -284,6 +284,16 @@ export class TwitterTimelineBehavior
       yield* this.followExternalLinks(ctx);
 
       this.seenTweets.add(window.location.href);
+
+      // If this is a tweet by the profile this crawl is capturing,
+      // queue the individual tweet to be captured standalone too.
+      if (this.urlIsTweet() && this.username == this.currentUrlUsername()) {
+        yield getState(
+          ctx,
+          "Queuing Individual Tweet URL: " + window.location.href,
+        );
+        await addLink(window.location.href);
+      }
 
       // wait
       await sleep(waitUnit * 2);

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -427,6 +427,9 @@ export class TwitterTimelineBehavior
         const mediaTabUrl = window.location.href + "/media";
         yield getState(ctx, "Queuing Media Tab: " + mediaTabUrl);
         await addLink(mediaTabUrl);
+        // The default media tab is for videos; there's also a photo
+        // version, which we can visit with a separate query parameter.
+        await addLink(mediaTabUrl + "?filter=photo");
       }
     }
 

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -337,6 +337,10 @@ export class TwitterTimelineBehavior
     }
   }
 
+  isLoggedIn() {
+    return !document.documentElement.outerHTML.match(/Log In/i);
+  }
+
   async *run(ctx: Context<TwitterState, TwitterOpts>) {
     yield* this.iterTimeline(ctx, 0);
   }
@@ -344,9 +348,6 @@ export class TwitterTimelineBehavior
   async awaitPageLoad(ctx: Context<TwitterState, TwitterOpts>) {
     const { sleep, assertContentValid } = ctx.Lib;
     await sleep(5);
-    assertContentValid(
-      () => !document.documentElement.outerHTML.match(/Log In/i),
-      "not_logged_in",
-    );
+    assertContentValid(() => this.isLoggedIn(), "not_logged_in");
   }
 }

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -334,7 +334,7 @@ export class TwitterTimelineBehavior
           // When logged out, these links go directly to the linked sites;
           // when logged in, these will be t.co links.
           if (!link.href.match(/https?:\/\/x.com/)) {
-            yield getState(ctx, "Following external link: " + link.href);
+            yield getState(ctx, "Following External Link: " + link.href);
             await addLink(link.href);
           }
         }

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -424,7 +424,7 @@ export class TwitterTimelineBehavior
 
       // Media tab can't be visited at all when logged out
       if (this.isLoggedIn()) {
-        const mediaTabUrl = window.location.href + "/media";
+        const mediaTabUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}/media`;
         yield getState(ctx, "Queuing Media Tab: " + mediaTabUrl);
         await addLink(mediaTabUrl);
         // The default media tab is for videos; there's also a photo

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -40,6 +40,7 @@ export class TwitterTimelineBehavior
 {
   seenTweets: Set<string>;
   seenMediaTweets: Set<string>;
+  username: string | null;
 
   static id = "Twitter" as const;
 
@@ -63,6 +64,7 @@ export class TwitterTimelineBehavior
   constructor() {
     this.seenTweets = new Set();
     this.seenMediaTweets = new Set();
+    this.username = null;
   }
 
   showingProgressBar(
@@ -279,6 +281,8 @@ export class TwitterTimelineBehavior
         yield* this.iterTimeline(ctx, depth + 1);
       }
 
+      yield* this.followExternalLinks(ctx);
+
       this.seenTweets.add(window.location.href);
 
       // wait
@@ -287,6 +291,42 @@ export class TwitterTimelineBehavior
       await tweetState.goBack(Q.backButton);
 
       await sleep(waitUnit);
+    }
+  }
+
+  async *followExternalLinks(ctx: Context<TwitterState, TwitterOpts>) {
+    const { addLink, getState, xpathNode, xpathNodes } = ctx.Lib;
+
+    // Follow links within the tweet text, but only if it's a tweet
+    // for the account being crawled
+    if (this.urlIsTweet() && this.username == this.currentUrlUsername()) {
+      const statusId = this.statusIdForUrl();
+
+      const query = `//article[@data-tweet-id='${statusId}']`;
+      const tweet = xpathNode(query);
+
+      if (tweet) {
+        for (const link of xpathNodes(
+          ".//a[@target='_blank']",
+          tweet,
+        ) as Generator<HTMLAnchorElement>) {
+          // Don't follow internal links, only external ones
+          // NOTE: these don't seem to be t.co anymore??
+          if (!link.href.match(/https?:\/\/x.com/)) {
+            yield getState(ctx, "Following external link: " + link.href);
+            await addLink(link.href);
+          }
+        }
+      }
+    }
+  }
+
+  statusIdForUrl() {
+    const match = window.location.pathname.match(
+      /^\/[a-zA-Z0-9_]+\/status\/(\d+)$/,
+    );
+    if (match) {
+      return match[1];
     }
   }
 
@@ -341,7 +381,19 @@ export class TwitterTimelineBehavior
     return !document.documentElement.outerHTML.match(/Log In/i);
   }
 
+  currentUrlUsername() {
+    if (window.location.pathname.match(/^\/[a-zA-Z0-9_]+$/)) {
+      return window.location.pathname.split("/")[1];
+    }
+  }
+
+  urlIsTweet() {
+    return !!window.location.pathname.match(/^\/[a-zA-Z0-9_]+\/status/);
+  }
+
   async *run(ctx: Context<TwitterState, TwitterOpts>) {
+    this.username = this.currentUrlUsername();
+
     yield* this.iterTimeline(ctx, 0);
   }
 

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -327,6 +327,9 @@ export class TwitterTimelineBehavior
 
       if (tweet) {
         for (const link of xpathNodes(
+          // All external links have target=_blank, so this helps us
+          // identify external links from within a tweet as opposed to
+          // internal links from the UI.
           ".//a[@target='_blank']",
           tweet,
         ) as Generator<HTMLAnchorElement>) {

--- a/src/site/twitter.ts
+++ b/src/site/twitter.ts
@@ -22,6 +22,7 @@ const Q = {
     ".//a[@href='/settings/content_you_see']/parent::div/parent::div/parent::div//div[@role='button']",
   progress: ".//*[@role='progressbar']",
   promoted: ".//div[data-testid='placementTracking']",
+  profilePageRegex: /^\/[a-zA-Z0-9_]+$/,
 };
 
 type TwitterState = {
@@ -40,7 +41,7 @@ export class TwitterTimelineBehavior
 {
   seenTweets: Set<string>;
   seenMediaTweets: Set<string>;
-  username: string | null;
+  username: string | undefined;
 
   static id = "Twitter" as const;
 
@@ -64,7 +65,7 @@ export class TwitterTimelineBehavior
   constructor() {
     this.seenTweets = new Set();
     this.seenMediaTweets = new Set();
-    this.username = null;
+    this.username = undefined;
   }
 
   showingProgressBar(
@@ -392,9 +393,13 @@ export class TwitterTimelineBehavior
   }
 
   currentUrlUsername() {
-    if (window.location.pathname.match(/^\/[a-zA-Z0-9_]+$/)) {
+    if (this.urlIsProfilePage()) {
       return window.location.pathname.split("/")[1];
     }
+  }
+
+  urlIsProfilePage() {
+    return !!window.location.pathname.match(Q.profilePageRegex);
   }
 
   urlIsTweet() {
@@ -402,7 +407,18 @@ export class TwitterTimelineBehavior
   }
 
   async *run(ctx: Context<TwitterState, TwitterOpts>) {
-    this.username = this.currentUrlUsername();
+    const { addLink, getState } = ctx.Lib;
+
+    if (this.urlIsProfilePage()) {
+      this.username = this.currentUrlUsername();
+
+      // Media tab can't be visited at all when logged out
+      if (this.isLoggedIn()) {
+        const mediaTabUrl = window.location.href + "/media";
+        yield getState(ctx, "Queuing Media Tab: " + mediaTabUrl);
+        await addLink(mediaTabUrl);
+      }
+    }
 
     yield* this.iterTimeline(ctx, 0);
   }


### PR DESCRIPTION
This introduces smart scoping to the twitter behaviour with a few new features:

* When a crawl begins on a specific profile, we track the username and use that to make decisions on extra links to follow.
* When viewing tweets by the profile we're archiving, we will also crawl the individual pages for those tweets.
* Capture external links too, but only when contained within tweets by the profile we're archiving. We explicitly ignore external links from any other tweets we encounter.
* When logged in, add the media tabs to the list of pages to browse.

We currently don't do anything special with it. The current version of the media tab is just a timeline of tweets (unlike the old photo grid that would have taken special handling), so we probably don't *need* special handling anymore. There are two versions, one for videos and one for photos, which are separated out by query parameters. We'll try to visit both.