### PR TITLE
instagram: restrict login check to safe-looking URLs

### DIFF
--- a/src/site/instagram.ts
+++ b/src/site/instagram.ts
@@ -391,9 +391,15 @@ export class InstagramPostsBehavior
     // before the photos become available.
     await waitUntilNode(Q.rootPath, document, null, 18000);
 
-    assertContentValid(
-      () => !!document.querySelector("*[aria-label='New post']"),
-      "not_logged_in",
-    );
+    // Looks like something we can safely run a login check on
+    if (
+      window.location.pathname.startsWith("/p/") ||
+      !!Q.userPage.exec(window.location.pathname)
+    ) {
+      assertContentValid(
+        () => !!document.querySelector("*[aria-label='New post']"),
+        "not_logged_in",
+      );
+    }
   }
 }


### PR DESCRIPTION
We recently had a case where the scoping on a site allowed the crawl to wander on to `/web/lite/`, which isn't safe for the login check to run. This post moves the login check to only run on post and profile URLs for increased safety.