### PR TITLE
Remove startEarly flag

### DIFF
--- a/src/autofetcher.ts
+++ b/src/autofetcher.ts
@@ -39,11 +39,7 @@ export class AutoFetcher extends BackgroundBehavior {
 
   static id = "Autofetcher" as const;
 
-  constructor(
-    active = false,
-    headers: Record<string, string> | null = null,
-    startEarly = false,
-  ) {
+  constructor(active = false, headers: Record<string, string> | null = null) {
     super();
 
     this.headers = headers || {};
@@ -51,9 +47,6 @@ export class AutoFetcher extends BackgroundBehavior {
     this._donePromise = new Promise((resolve) => (this._markDone = resolve));
 
     this.active = active;
-    if (this.active && startEarly) {
-      document.addEventListener("DOMContentLoaded", () => this.initObserver());
-    }
   }
 
   get numFetching() {

--- a/src/autoplay.ts
+++ b/src/autoplay.ts
@@ -17,7 +17,7 @@ export class Autoplay extends BackgroundBehavior {
 
   static id = "Autoplay" as const;
 
-  constructor(autofetcher: AutoFetcher, startEarly = false) {
+  constructor(autofetcher: AutoFetcher) {
     super();
     this.mediaSet = new Set();
     this.autofetcher = autofetcher;
@@ -25,11 +25,9 @@ export class Autoplay extends BackgroundBehavior {
     this.promises = [];
     this._initDone = () => null;
     this.promises.push(new Promise((resolve) => (this._initDone = resolve)));
-    if (startEarly) {
-      document.addEventListener("DOMContentLoaded", async () =>
-        this.pollAudioVideo(),
-      );
-    }
+    document.addEventListener("DOMContentLoaded", async () =>
+      this.pollAudioVideo(),
+    );
   }
 
   async start() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ interface BehaviorManagerOpts {
   siteSpecific?: boolean | Record<string, unknown>;
   timeout?: number;
   fetchHeaders?: Record<string, string> | null;
-  startEarly?: boolean | null;
   clickSelector?: string;
 }
 
@@ -136,7 +135,6 @@ export class BehaviorManager {
     this.autofetch = new AutoFetcher(
       !!opts.autofetch,
       opts.fetchHeaders,
-      !!opts.startEarly,
     );
 
     if (opts.autofetch) {
@@ -146,7 +144,7 @@ export class BehaviorManager {
 
     if (opts.autoplay) {
       void behaviorLog("Using Autoplay");
-      this.behaviors.push(new Autoplay(this.autofetch, !!opts.startEarly));
+      this.behaviors.push(new Autoplay(this.autofetch));
     }
 
     if (opts.autoclick) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,10 +132,7 @@ export class BehaviorManager {
       }
     }
 
-    this.autofetch = new AutoFetcher(
-      !!opts.autofetch,
-      opts.fetchHeaders,
-    );
+    this.autofetch = new AutoFetcher(!!opts.autofetch, opts.fetchHeaders);
 
     if (opts.autofetch) {
       void behaviorLog("Using AutoFetcher");


### PR DESCRIPTION
We're backing away from this and setting a default for both features:

* autofetcher goes for late initialization in order to avoid the early startup causing the page load to lock up for several seconds
* autoplay keeps early initialization, since this has significant upsides without performance downsides