### PR TITLE
add priotity: "low" to autofetch fetch() requests to be able to skip …

### DIFF
--- a/src/autofetcher.ts
+++ b/src/autofetcher.ts
@@ -151,6 +151,7 @@ export class AutoFetcher extends BackgroundBehavior {
         credentials: "include",
         referrerPolicy: "origin-when-cross-origin",
         headers: this.headers,
+        priority: "low"
       } as {});
       this.debug(`Autofetch: started non-cors stream for ${url}`);
       return true;

--- a/src/autofetcher.ts
+++ b/src/autofetcher.ts
@@ -151,7 +151,7 @@ export class AutoFetcher extends BackgroundBehavior {
         credentials: "include",
         referrerPolicy: "origin-when-cross-origin",
         headers: this.headers,
-        priority: "low"
+        priority: "low",
       } as {});
       this.debug(`Autofetch: started non-cors stream for ${url}`);
       return true;


### PR DESCRIPTION
…loading them if duplicates

see: webrecorder/browsertrix-crawler#1156