### PR TITLE
add registerFrame() call to register this frame

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   registerFrame,
 } from "./lib/utils";
 import { type AbstractBehavior, BehaviorRunner } from "./lib/behavior";
+import * as Lib from "./lib/utils";
 
 import siteBehaviors from "./site";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,9 @@ import {
   installBehaviors,
   addLinkBatch,
   checkToJsonOverride,
+  registerFrame,
 } from "./lib/utils";
 import { type AbstractBehavior, BehaviorRunner } from "./lib/behavior";
-import * as Lib from "./lib/utils";
 
 import siteBehaviors from "./site";
 
@@ -109,6 +109,8 @@ export class BehaviorManager {
     if (!self.window) {
       return;
     }
+
+    registerFrame();
 
     this.timeout = opts.timeout;
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -156,7 +156,7 @@ export async function behaviorLog(data: LogData, type = "debug") {
 
 export function registerFrame() {
   if (typeof self["__bx_registerFrame"] === "function") {
-    // call directly as passing two objects
+    // pass location of frame
     self["__bx_registerFrame"](self.location.href);
     return true;
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -154,6 +154,16 @@ export async function behaviorLog(data: LogData, type = "debug") {
   }
 }
 
+export function registerFrame() {
+  if (typeof self["__bx_registerFrame"] === "function") {
+    // call directly as passing two objects
+    self["__bx_registerFrame"](self.location.href);
+    return true;
+  }
+
+  return false;
+}
+
 export async function addLink(
   url: string,
   alwaysObeyScope = false,


### PR DESCRIPTION
If registerFrame() callback is defined, allows tracking which frames have initialized behaviors via CDP.