### PR TITLE
call registerFrame() in constructor,

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-behaviors",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "main": "index.js",
   "author": "Webrecorder Software",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ export class BehaviorManager {
       extractName: DEFAULT_LINK_EXTRACT,
     };
     void behaviorLog("Loaded behaviors for: " + self.location.href);
+    registerFrame();
   }
 
   init(
@@ -110,8 +111,6 @@ export class BehaviorManager {
     if (!self.window) {
       return;
     }
-
-    registerFrame();
 
     this.timeout = opts.timeout;
 


### PR DESCRIPTION
to ensure link extraction is available and extractLinks() can be called even if no behaviors are initialized
and init() is never called
bump to 0.14.1